### PR TITLE
Fixes for Windows Phone design-time errors

### DIFF
--- a/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/ScaleLine/ScaleLine.cs
+++ b/src/Common/Esri.ArcGISRuntime.Toolkit/Controls/ScaleLine/ScaleLine.cs
@@ -164,6 +164,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
         /// </summary>
         private void Refresh()
         {
+#if WINDOWS_PHONE_APP
+            if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
+                return;
+#endif
+
             var miles = GetMile();
             SetUsUnit(
                 miles >= 1 ? miles : GetFoot(), 

--- a/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Control/SignInDialog/SignInDialog.cs
+++ b/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Control/SignInDialog/SignInDialog.cs
@@ -18,9 +18,10 @@ using Esri.ArcGISRuntime.Security;
 #error "Intended for WinPhone only"
 #endif
 
-namespace Esri.ArcGISRuntime.Toolkit.Controls
+namespace Esri.ArcGISRuntime.Toolkit.Controls.Primitives
 {
     /// <summary>
+    /// *FOR INTERNAL USE ONLY*
     /// The SignInDialog Control challenges the user for a credential
     /// when trying to access secured ArcGIS services.
     /// The SignInDialog Control can manage Network or Token credential.
@@ -28,7 +29,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
     /// <remarks>
     /// This control is designed to work with the <see cref="IdentityManager" /> and the <see cref="Security.SignInChallengeHandler"/>.
     /// </remarks>
-    internal class SignInDialog : Control, INotifyPropertyChanged // might be public later
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class SignInDialog : Control, INotifyPropertyChanged
     {
         #region Constructors
         private TaskCompletionSource<Credential> _tcs;
@@ -398,7 +400,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
     /// </summary>
     /// <exclude/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal class SignInDialogMessageConverter : IValueConverter
+    public class SignInDialogMessageConverter : IValueConverter
     {
 
         /// <summary>
@@ -463,7 +465,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
     /// </summary>
     /// <exclude/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal class CredentialSaveOptionBoolConverter : IValueConverter
+    public class CredentialSaveOptionBoolConverter : IValueConverter
     {
         /// <summary>
         /// Modifies the source data before passing it to the target for display in the UI.
@@ -512,7 +514,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Controls
     /// </summary>
     /// <exclude/>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal class CredentialSaveOptionVisibilityConverter : IValueConverter
+    public class CredentialSaveOptionVisibilityConverter : IValueConverter
     {
         /// <summary>
         /// Modifies the source data before passing it to the target for display in the UI.

--- a/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Security/SignInChallengeHandler.cs
+++ b/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Security/SignInChallengeHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Windows.Security.Credentials;
 using Esri.ArcGISRuntime.Security;
 using Esri.ArcGISRuntime.Toolkit.Controls;
+using Esri.ArcGISRuntime.Toolkit.Controls.Primitives;
 
 #if !WINDOWS_PHONE_APP
 #error "Intended for WinPhone only"

--- a/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Themes/Generic.xaml
+++ b/src/WinPhone/Esri.ArcGISRuntime.Toolkit/Themes/Generic.xaml
@@ -500,17 +500,17 @@
     </Style>
 
 
-    <Style TargetType="local:SignInDialog">
+    <Style TargetType="primitives:SignInDialog">
         <Setter Property="Title" Value="Sign In" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="local:SignInDialog">
+                <ControlTemplate TargetType="primitives:SignInDialog">
                     <Grid>
                         <Grid.Resources>
                             <converters:VisibilityConverter x:Key="VisibilityConverter" />
-                            <local:SignInDialogMessageConverter x:Key="MessageConverter" />
-                            <local:CredentialSaveOptionBoolConverter x:Key="CredentialSaveOptionBoolConverter" />
-                            <local:CredentialSaveOptionVisibilityConverter x:Key="CredentialSaveOptionVisibilityConverter" />
+                            <primitives:SignInDialogMessageConverter x:Key="MessageConverter" />
+                            <primitives:CredentialSaveOptionBoolConverter x:Key="CredentialSaveOptionBoolConverter" />
+                            <primitives:CredentialSaveOptionVisibilityConverter x:Key="CredentialSaveOptionVisibilityConverter" />
                         </Grid.Resources>
 
                         <StackPanel HorizontalAlignment="Stretch">


### PR DESCRIPTION
Addresses #97.  COM exception was caused by SignInDialog and converters being internal, but included in generic.xaml.  Resolved by making types public.  Changes also include a fix for ScaleLine, which was throwing an error at design-time once the COM exception was resolved.