### PR TITLE
Scalebar: Add support for Android and Xamarin Forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ project.lock.json
 
 # UWP auto-generated NuGet file
 *.nuget.targets
+
+# Xamarin Android auto-generated resource file
+*Resource.Designer.cs

--- a/src/Esri.ArcGISRuntime.Toolkit.sln
+++ b/src/Esri.ArcGISRuntime.Toolkit.sln
@@ -29,11 +29,14 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Esri.ArcGISRuntime.Toolkit.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP", "Esri.ArcGISRuntime.Toolkit\XamarinForms\UWP\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP.csproj", "{789DFC6B-E631-4002-90A4-CA6609DB4CAE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.iOS", "Esri.ArcGISRuntime.Toolkit\XamarinForms\iOS\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.iOS.csproj", "{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3596c206-41c8-4405-a5c7-382e79e8d091}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3cb7f885-c81c-44dc-8af6-3dbbc983422f}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{789dfc6b-e631-4002-90a4-ca6609db4cae}*SharedItemsImports = 4
+		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{a3c4f5ed-a5bf-4fac-9d20-9b4222578333}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{a8c6414a-fbe0-40d6-ab0e-5f35cde53b4a}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{b845a5fb-b7bd-4085-867e-e44bf36af5ab}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{c8657c80-a1ab-4d77-9f75-c923ab330afb}*SharedItemsImports = 13
@@ -187,6 +190,22 @@ Global
 		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x64.Build.0 = Release|x64
 		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x86.ActiveCfg = Release|x86
 		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x86.Build.0 = Release|x86
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|ARM.Build.0 = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Debug|x86.Build.0 = Debug|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|ARM.Build.0 = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|x64.Build.0 = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,6 +222,7 @@ Global
 		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 		{D3D6AAED-8C2E-4177-B59C-C640E3681B3D} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 		{789DFC6B-E631-4002-90A4-CA6609DB4CAE} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
+		{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E4123114-3398-48EA-ACDD-7F636647FF6B}

--- a/src/Esri.ArcGISRuntime.Toolkit.sln
+++ b/src/Esri.ArcGISRuntime.Toolkit.sln
@@ -27,10 +27,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared", "Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.shproj", "{D3D6AAED-8C2E-4177-B59C-C640E3681B3D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP", "Esri.ArcGISRuntime.Toolkit\XamarinForms\UWP\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP.csproj", "{789DFC6B-E631-4002-90A4-CA6609DB4CAE}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3596c206-41c8-4405-a5c7-382e79e8d091}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3cb7f885-c81c-44dc-8af6-3dbbc983422f}*SharedItemsImports = 4
+		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{789dfc6b-e631-4002-90a4-ca6609db4cae}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{a8c6414a-fbe0-40d6-ab0e-5f35cde53b4a}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{b845a5fb-b7bd-4085-867e-e44bf36af5ab}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{c8657c80-a1ab-4d77-9f75-c923ab330afb}*SharedItemsImports = 13
@@ -168,6 +171,22 @@ Global
 		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x64.Build.0 = Release|Any CPU
 		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x86.ActiveCfg = Release|Any CPU
 		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x86.Build.0 = Release|Any CPU
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|ARM.ActiveCfg = Debug|ARM
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|ARM.Build.0 = Debug|ARM
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|x64.ActiveCfg = Debug|x64
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|x64.Build.0 = Debug|x64
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|x86.ActiveCfg = Debug|x86
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Debug|x86.Build.0 = Debug|x86
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|ARM.ActiveCfg = Release|ARM
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|ARM.Build.0 = Release|ARM
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x64.ActiveCfg = Release|x64
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x64.Build.0 = Release|x64
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x86.ActiveCfg = Release|x86
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -183,6 +202,7 @@ Global
 		{4AF3E27B-DCAB-4819-8ECE-C55FCF54391A} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
 		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 		{D3D6AAED-8C2E-4177-B59C-C640E3681B3D} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
+		{789DFC6B-E631-4002-90A4-CA6609DB4CAE} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E4123114-3398-48EA-ACDD-7F636647FF6B}

--- a/src/Esri.ArcGISRuntime.Toolkit.sln
+++ b/src/Esri.ArcGISRuntime.Toolkit.sln
@@ -19,12 +19,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Toolkit.Samples.WPF", "Samp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.iOS", "Esri.ArcGISRuntime.Toolkit\iOS\Esri.ArcGISRuntime.Toolkit.iOS.csproj", "{B845A5FB-B7BD-4085-867E-E44BF36AF5AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Android", "Esri.ArcGISRuntime.Toolkit\Android\Esri.ArcGISRuntime.Toolkit.Android.csproj", "{F8BA7263-7923-4B29-AA86-9D42B38E0889}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3596c206-41c8-4405-a5c7-382e79e8d091}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3cb7f885-c81c-44dc-8af6-3dbbc983422f}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{b845a5fb-b7bd-4085-867e-e44bf36af5ab}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{c8657c80-a1ab-4d77-9f75-c923ab330afb}*SharedItemsImports = 13
+		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{f8ba7263-7923-4b29-aa86-9d42b38e0889}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +128,22 @@ Global
 		{B845A5FB-B7BD-4085-867E-E44BF36AF5AB}.Release|x64.Build.0 = Release|Any CPU
 		{B845A5FB-B7BD-4085-867E-E44BF36AF5AB}.Release|x86.ActiveCfg = Release|Any CPU
 		{B845A5FB-B7BD-4085-867E-E44BF36AF5AB}.Release|x86.Build.0 = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|x64.Build.0 = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Debug|x86.Build.0 = Debug|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|ARM.Build.0 = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x64.ActiveCfg = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x64.Build.0 = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x86.ActiveCfg = Release|Any CPU
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -136,5 +155,9 @@ Global
 		{C8657C80-A1AB-4D77-9F75-C923AB330AFB} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
 		{75555B1C-1AED-401F-BEC6-A791AAB70D57} = {FB597A95-9488-44D2-B5CC-F2FFAD2A29CD}
 		{B845A5FB-B7BD-4085-867E-E44BF36AF5AB} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
+		{F8BA7263-7923-4B29-AA86-9D42B38E0889} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E4123114-3398-48EA-ACDD-7F636647FF6B}
 	EndGlobalSection
 EndGlobal

--- a/src/Esri.ArcGISRuntime.Toolkit.sln
+++ b/src/Esri.ArcGISRuntime.Toolkit.sln
@@ -21,12 +21,20 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Android", "Esri.ArcGISRuntime.Toolkit\Android\Esri.ArcGISRuntime.Toolkit.Android.csproj", "{F8BA7263-7923-4B29-AA86-9D42B38E0889}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Xamarin Forms", "Xamarin Forms", "{4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android", "Esri.ArcGISRuntime.Toolkit\XamarinForms\Android\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android.csproj", "{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared", "Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.shproj", "{D3D6AAED-8C2E-4177-B59C-C640E3681B3D}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3596c206-41c8-4405-a5c7-382e79e8d091}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{3cb7f885-c81c-44dc-8af6-3dbbc983422f}*SharedItemsImports = 4
+		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{a8c6414a-fbe0-40d6-ab0e-5f35cde53b4a}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{b845a5fb-b7bd-4085-867e-e44bf36af5ab}*SharedItemsImports = 4
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{c8657c80-a1ab-4d77-9f75-c923ab330afb}*SharedItemsImports = 13
+		Esri.ArcGISRuntime.Toolkit\XamarinForms\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems*{d3d6aaed-8c2e-4177-b59c-c640e3681b3d}*SharedItemsImports = 13
 		Esri.ArcGISRuntime.Toolkit\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems*{f8ba7263-7923-4b29-aa86-9d42b38e0889}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -144,6 +152,22 @@ Global
 		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x64.Build.0 = Release|Any CPU
 		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x86.ActiveCfg = Release|Any CPU
 		{F8BA7263-7923-4B29-AA86-9D42B38E0889}.Release|x86.Build.0 = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|ARM.Build.0 = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|x64.Build.0 = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Debug|x86.Build.0 = Debug|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|ARM.Build.0 = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x64.ActiveCfg = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x64.Build.0 = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x86.ActiveCfg = Release|Any CPU
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +180,9 @@ Global
 		{75555B1C-1AED-401F-BEC6-A791AAB70D57} = {FB597A95-9488-44D2-B5CC-F2FFAD2A29CD}
 		{B845A5FB-B7BD-4085-867E-E44BF36AF5AB} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
 		{F8BA7263-7923-4B29-AA86-9D42B38E0889} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
+		{4AF3E27B-DCAB-4819-8ECE-C55FCF54391A} = {30B1D58C-DDDA-40F3-ACAB-A5516896AB4B}
+		{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
+		{D3D6AAED-8C2E-4177-B59C-C640E3681B3D} = {4AF3E27B-DCAB-4819-8ECE-C55FCF54391A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E4123114-3398-48EA-ACDD-7F636647FF6B}

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
@@ -49,6 +49,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\WPF\Resources.cs">
+      <Link>Properties\Resources.cs</Link>
+    </Compile>
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
@@ -10,7 +10,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Esri.ArcGISRuntime.Toolkit</RootNamespace>
-    <AssemblyName>Esri.ArcGISRuntime.Toolkit.Android</AssemblyName>
+    <AssemblyName>Esri.ArcGISRuntime.Toolkit</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
@@ -54,6 +54,8 @@
     </Compile>
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UI\Controls\ScaleLine.Android.cs" />
+    <Compile Include="UI\RectangleView.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/Esri.ArcGISRuntime.Toolkit.Android.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F8BA7263-7923-4B29-AA86-9D42B38E0889}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Esri.ArcGISRuntime.Toolkit</RootNamespace>
+    <AssemblyName>Esri.ArcGISRuntime.Toolkit.Android</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;__ANDROID__;XAMARIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;__ANDROID__;XAMARIN</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\lib\MonoAndroid10\Esri.ArcGISRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\WPF\LocalizedStrings\Resources.resx">
+      <Link>LocalizedStrings\Resources.resx</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <Import Project="..\Shared\Esri.ArcGISRuntime.Toolkit.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets" Condition="Exists('..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/Properties/AssemblyInfo.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Android.App;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Esri.ArcGISRuntime.Toolkit")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Esri")]
+[assembly: AssemblyProduct("Esri.ArcGISRuntime.Toolkit")]
+[assembly: AssemblyCopyright("Copyright ©Esri 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/UI/Controls/ScaleLine.Android.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/UI/Controls/ScaleLine.Android.cs
@@ -1,0 +1,276 @@
+﻿// /*******************************************************************************
+//  * Copyright 2017 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using Android.App;
+using Android.Content;
+using Android.Graphics;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
+{
+    [Register("Esri.ArcGISRuntime.Toolkit.UI.Controls.ScaleLine")]
+    public partial class ScaleLine
+    {
+        private static DisplayMetrics s_displayMetrics;
+        private static IWindowManager s_windowManager;
+        private RectangleView _firstMetricTickLine;
+        private RectangleView _secondMetricTickLine;
+        private RectangleView _scaleLineStartSegment;
+        private RectangleView _firstUsTickLine;
+        private RectangleView _secondUsTickLine;
+        private RectangleView _combinedScaleLine;
+        private RectangleView _metricWidthPlaceholder;
+        private RectangleView _usWidthPlaceholder;
+        private LinearLayout _rootLayout;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScaleLine"/> class.
+        /// </summary>
+        /// <param name="context">The Context the view is running in, through which it can access resources, themes, etc</param>
+        /// <param name="attr">The attributes of the AXML element declaring the view</param>
+        public ScaleLine(Context context, IAttributeSet attr) : base(context, attr) => Initialize();
+
+        private void Initialize()
+        {
+            if (!DesignTime.IsDesignMode)
+                TargetWidth = CalculateScreenDimension(200);
+
+            // Vertically-oriented layout for containing all scalebar components
+            _rootLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Vertical,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+            _rootLayout.SetGravity(GravityFlags.Top);
+
+            // Initialize scalebar components with placeholder sizes and values
+            var scalelineHeight = CalculateScreenDimension(2);
+            _combinedScaleLine = new RectangleView(Context, TargetWidth, scalelineHeight) { BackgroundColor = ForegroundColor };
+            _metricScaleLine = new RectangleView(Context, TargetWidth, 1);
+            _metricValue = new TextView(Context) { Text = "100" };
+            _metricUnit = new TextView(Context) { Text = "m" };
+            _usScaleLine = new RectangleView(Context, _metricScaleLine.Width * .9144, 1);
+            _usValue = new TextView(Context) { Text = "300" };
+            _usUnit = new TextView(Context) { Text = "ft" };
+
+            var fontSize = 12;
+            _metricValue.SetTextSize(ComplexUnitType.Dip, fontSize);
+            _metricValue.SetTextColor(ForegroundColor);
+            _metricUnit.SetTextSize(ComplexUnitType.Dip, fontSize);
+            _metricUnit.SetTextColor(ForegroundColor);
+            _usValue.SetTextSize(ComplexUnitType.Dip, fontSize);
+            _usValue.SetTextColor(ForegroundColor);
+            _usUnit.SetTextSize(ComplexUnitType.Dip, fontSize);
+            _usUnit.SetTextColor(ForegroundColor);
+
+            // Listen for width updates on metric and imperial scale lines to update the combined scale line
+            _metricScaleLine.PropertyChanged += ScaleLine_PropertyChanged;
+            _usScaleLine.PropertyChanged += ScaleLine_PropertyChanged;
+
+            // ===============================================================
+            // First row - placeholder, numeric text, and units text
+            // ===============================================================
+            var firstRowLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Horizontal,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+
+            firstRowLayout.AddView(_metricScaleLine);
+            firstRowLayout.AddView(_metricValue);
+            firstRowLayout.AddView(_metricUnit);
+
+            // ================================================================================
+            // Second row - first metric tick line, placeholder, and second metric tick line
+            // ================================================================================
+            var secondRowLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Horizontal,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+
+            var tickWidth = CalculateScreenDimension(2);
+            var tickHeight = CalculateScreenDimension(5);
+
+            _firstMetricTickLine = new RectangleView(Context, tickWidth, tickHeight) { BackgroundColor = ForegroundColor };
+
+            _metricWidthPlaceholder = new RectangleView(Context, _metricScaleLine.Width, 1);
+            _secondMetricTickLine = new RectangleView(Context, tickWidth, tickHeight) { BackgroundColor = ForegroundColor };
+
+            secondRowLayout.AddView(_firstMetricTickLine);
+            secondRowLayout.AddView(_metricWidthPlaceholder);
+            secondRowLayout.AddView(_secondMetricTickLine);
+
+            // ==============================================================================================
+            // Third row - filler segment at start of scale line, combined metric/imperial scale line
+            // ==============================================================================================
+            var thirdRowLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Horizontal,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+
+            _scaleLineStartSegment = new RectangleView(Context, Math.Round(tickWidth) * 2, scalelineHeight) { BackgroundColor = ForegroundColor };
+
+            thirdRowLayout.AddView(_scaleLineStartSegment);
+            thirdRowLayout.AddView(_combinedScaleLine);
+
+            // ==============================================================================================
+            // Fourth row - first imperial tick line, placeholder, second imperial tick line
+            // ==============================================================================================
+            var fourthRowLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Horizontal,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+
+            _firstUsTickLine = new RectangleView(Context, tickWidth, tickHeight) { BackgroundColor = ForegroundColor };
+            _secondUsTickLine = new RectangleView(Context, tickWidth, tickHeight) { BackgroundColor = ForegroundColor };
+
+            fourthRowLayout.AddView(_firstUsTickLine);
+            fourthRowLayout.AddView(_usScaleLine);
+            fourthRowLayout.AddView(_secondUsTickLine);
+
+            // ==========================================================================
+            // Fifth row - placeholder, imperial numeric text, imperial unit text
+            // ==========================================================================
+            var fifthRowLayout = new LinearLayout(Context)
+            {
+                Orientation = Orientation.Horizontal,
+                LayoutParameters = new LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent)
+            };
+
+            _usWidthPlaceholder = new RectangleView(Context, _usScaleLine.Width, 1);
+
+            fifthRowLayout.AddView(_usWidthPlaceholder);
+            fifthRowLayout.AddView(_usValue);
+            fifthRowLayout.AddView(_usUnit);
+
+            // Add all scalebar rows to the root layout
+            _rootLayout.AddView(firstRowLayout);
+            _rootLayout.AddView(secondRowLayout);
+            _rootLayout.AddView(thirdRowLayout);
+            _rootLayout.AddView(fourthRowLayout);
+            _rootLayout.AddView(fifthRowLayout);
+
+            // Add root layout to view
+            AddView(_rootLayout);
+            _rootLayout.RequestLayout();
+        }
+
+        private Color _foregroundColor = Color.Black;
+
+        /// <summary>
+        /// Gets or sets the color of the foreground elements of the <see cref="ScaleLine"/>
+        /// </summary>
+        public Color ForegroundColor
+        {
+            get => _foregroundColor;
+            set
+            {
+                _foregroundColor = value;
+
+                if (_metricScaleLine == null)
+                    return;
+
+                // Apply specified color to scalebar elements
+                _combinedScaleLine.BackgroundColor = value;
+                _metricUnit.SetTextColor(value);
+                _metricValue.SetTextColor(value);
+                _usUnit.SetTextColor(value);
+                _usValue.SetTextColor(value);
+                _firstMetricTickLine.BackgroundColor = value;
+                _secondMetricTickLine.BackgroundColor = value;
+                _firstUsTickLine.BackgroundColor = value;
+                _secondUsTickLine.BackgroundColor = value;
+                _scaleLineStartSegment.BackgroundColor = value;
+            }
+        }
+
+        private void ScaleLine_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            // Synchronize place holder widths with calculated imperial and metric line widths
+            _metricWidthPlaceholder.Width = _metricScaleLine.Width;
+            _usWidthPlaceholder.Width = _usScaleLine.Width;
+
+            // Update the scale line to be the longer of the metric or imperial lines
+            _combinedScaleLine.Width = _metricScaleLine.Width > _usScaleLine.Width ? _metricScaleLine.Width : _usScaleLine.Width;
+        }
+
+        private void SetVisibility(bool isVisible)
+        {
+            Visibility = isVisible ? Android.Views.ViewStates.Visible : Android.Views.ViewStates.Gone;
+        }
+
+        protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+        {
+            base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+
+            // Initialize dimensions of root layout
+            MeasureChild(_rootLayout, widthMeasureSpec, MeasureSpec.MakeMeasureSpec(MeasureSpec.GetSize(heightMeasureSpec), MeasureSpecMode.AtMost));
+
+            // Calculate the ideal width and height for the view
+            var desiredWidth = PaddingLeft + PaddingRight + _rootLayout.MeasuredWidth;
+            var desiredHeight = PaddingTop + PaddingBottom + _rootLayout.MeasuredHeight;
+
+            // Get the width and height of the view given any width and height constraints indicated by the width and height spec values
+            var width = ResolveSize(desiredWidth, widthMeasureSpec);
+            var height = ResolveSize(desiredHeight, heightMeasureSpec);
+            SetMeasuredDimension(width, height);
+        }
+
+        protected override void OnLayout(bool changed, int l, int t, int r, int b)
+        {
+            // Forward layout call to the root layout
+            _rootLayout.Layout(PaddingLeft, PaddingTop, _rootLayout.MeasuredWidth + PaddingLeft, _rootLayout.MeasuredHeight + PaddingBottom);
+        }
+
+        // Gets a display metrics object for calculating display dimensions
+        private static DisplayMetrics GetDisplayMetrics()
+        {
+            if (s_displayMetrics == null)
+            {
+                if (s_windowManager == null)
+                    s_windowManager = Application.Context?.GetSystemService(Context.WindowService)?.JavaCast<IWindowManager>();
+                if (s_windowManager == null)
+                {
+                    s_displayMetrics = Application.Context?.Resources?.DisplayMetrics;
+                }
+                else
+                {
+                    s_displayMetrics = new DisplayMetrics();
+                    s_windowManager.DefaultDisplay.GetMetrics(s_displayMetrics);
+                }
+            }
+            return s_displayMetrics;
+        }
+
+        // Calculates a screen dimension given a specified dimension in raw pixels
+        private float CalculateScreenDimension(float pixels, ComplexUnitType screenUnitType = ComplexUnitType.Dip)
+        {
+            return !DesignTime.IsDesignMode ?
+                TypedValue.ApplyDimension(screenUnitType, pixels, GetDisplayMetrics()) : pixels;
+        }
+    }
+}

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/UI/Controls/ScaleLine.Android.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/UI/Controls/ScaleLine.Android.cs
@@ -48,6 +48,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Initializes a new instance of the <see cref="ScaleLine"/> class.
         /// </summary>
         /// <param name="context">The Context the view is running in, through which it can access resources, themes, etc</param>
+        public ScaleLine(Context context) : base(context) => Initialize();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScaleLine"/> class.
+        /// </summary>
+        /// <param name="context">The Context the view is running in, through which it can access resources, themes, etc</param>
         /// <param name="attr">The attributes of the AXML element declaring the view</param>
         public ScaleLine(Context context, IAttributeSet attr) : base(context, attr) => Initialize();
 

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/UI/RectangleView.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/UI/RectangleView.cs
@@ -1,0 +1,111 @@
+﻿// /*******************************************************************************
+//  * Copyright 2017 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using Android.Content;
+using Android.Graphics;
+using Android.Views;
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI
+{
+    /// <summary>
+    /// Draws a rectangle on the screen
+    /// </summary>
+    /// <remarks>Provides a convenient mechanism for rendering rectangle elements of a certain size. The
+    /// specified width and height will be applied to the width and height of the view's layout parameters.</remarks>
+    internal class RectangleView : View, INotifyPropertyChanged
+    {
+        public RectangleView(Context context) : base(context) { }
+
+        public RectangleView(Context context, double width, double height) : this(context)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        private double _width;
+        /// <summary>
+        /// Gets or sets the rectangle's width
+        /// </summary>
+        public new double Width
+        {
+            get { return _width; }
+            set
+            {
+                _width = value;
+                var layoutParams = GetLayoutParams();
+                layoutParams.Width = (int)Math.Round(value);
+                LayoutParameters = layoutParams;
+                OnPropertyChanged();
+            }
+        }
+
+        private ViewGroup.LayoutParams GetLayoutParams()
+        {
+            if (LayoutParameters == null)
+            {
+                LayoutParameters = new ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.WrapContent,
+                    ViewGroup.LayoutParams.WrapContent);
+            }
+            return LayoutParameters;
+        }
+
+        private double _height;
+
+        /// <summary>
+        /// Gets or sets the rectangle's height
+        /// </summary>
+        public new double Height
+        {
+            get { return _height; }
+            set
+            {
+                _height = value;
+                var layoutParams = GetLayoutParams();
+                layoutParams.Height = (int)Math.Round(value);
+                LayoutParameters = layoutParams;
+                OnPropertyChanged();
+            }
+        }
+
+        private Color _backgroundColor;
+
+        /// <summary>
+        /// Gets or sets the rectangle's background color
+        /// </summary>
+        public Color BackgroundColor
+        {
+            get { return _backgroundColor; }
+            set
+            {
+                SetBackgroundColor(value);
+                _backgroundColor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged" />
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/src/Esri.ArcGISRuntime.Toolkit/Android/packages.config
+++ b/src/Esri.ArcGISRuntime.Toolkit/Android/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Esri.ArcGISRuntime" version="100.1.0" targetFramework="monoandroid60" />
+  <package id="Esri.ArcGISRuntime.Xamarin.Android" version="100.1.0" targetFramework="monoandroid60" />
+</packages>

--- a/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.Xamarin.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.Xamarin.cs
@@ -16,9 +16,6 @@
 
 #if XAMARIN
 using Esri.ArcGISRuntime.UI.Controls;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {

--- a/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.cs
@@ -25,6 +25,10 @@ using Windows.UI.Xaml.Shapes;
 using Control = UIKit.UIView;
 using TextBlock = UIKit.UILabel;
 using Rectangle = Esri.ArcGISRuntime.Toolkit.UI.RectangleView;
+#elif __ANDROID__
+using Control = Android.Views.ViewGroup;
+using TextBlock = Android.Widget.TextView;
+using Rectangle = Esri.ArcGISRuntime.Toolkit.UI.RectangleView;
 #else
 using System.Windows.Controls;
 using System.Windows.Shapes;
@@ -49,7 +53,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleLine"/> class.
         /// </summary>
-        public ScaleLine() => Initialize();
+        public ScaleLine
+#if __ANDROID__
+            (Android.Content.Context context) : base(context)
+#else
+            ()
+#endif
+            => Initialize();
 
 #pragma warning disable CS1587 // XML comment is not placed on a valid language element
         /// <summary>
@@ -254,5 +264,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             double distanceInInches = result.Distance;
             return distanceInInches * 96;
         }
+
     }
 }

--- a/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/Controls/ScaleLine/ScaleLine.cs
@@ -53,11 +53,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="ScaleLine"/> class.
         /// </summary>
-        public ScaleLine
+        public ScaleLine ()
 #if __ANDROID__
-            (Android.Content.Context context) : base(context)
-#else
-            ()
+            : base(Android.App.Application.Context)
 #endif
             => Initialize();
 

--- a/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/DesignTime.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Shared/UI/DesignTime.cs
@@ -41,7 +41,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                         = (bool)DependencyPropertyDescriptor
                         .FromProperty(prop, typeof(FrameworkElement))
                         .Metadata.DefaultValue;
-#elif XAMARIN
+#elif __ANDROID__
+                    // Assume we're in design-time if there is no application context
+                    s_isInDesignMode = Android.App.Application.Context == null;
+#else
                     s_isInDesignMode = false;
 #endif
                 }

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android.csproj
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A8C6414A-FBE0-40D6-AB0E-5F35CDE53B4A}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Esri.ArcGISRuntime.Xamarin.Forms.Android</RootNamespace>
+    <AssemblyName>Esri.ArcGISRuntime.Xamarin.Forms.Android</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\lib\MonoAndroid10\Esri.ArcGISRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Esri.ArcGISRuntime.Xamarin.Forms, Version=100.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Forms.100.1.0\lib\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Forms.dll</HintPath>
+    </Reference>
+    <Reference Include="FormsViewGroup, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="mscorlib" />
+    <Reference Include="OpenTK-1.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Xamarin.Android.Support.Animated.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.Animated.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Animated.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Design, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.Design.23.3.0\lib\MonoAndroid43\Xamarin.Android.Support.Design.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v4, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.v4.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.AppCompat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.v7.AppCompat.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.AppCompat.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.CardView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.v7.CardView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.CardView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.MediaRouter, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.v7.MediaRouter.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.MediaRouter.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v7.RecyclerView, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.v7.RecyclerView.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.v7.RecyclerView.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.Vector.Drawable, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\lib\MonoAndroid403\Xamarin.Android.Support.Vector.Drawable.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.Android, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Resources\Resource.Designer.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Android\Esri.ArcGISRuntime.Toolkit.Android.csproj">
+      <Project>{f8ba7263-7923-4b29-aa86-9d42b38e0889}</Project>
+      <Name>Esri.ArcGISRuntime.Toolkit.Android</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <Import Project="..\..\..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\..\..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Xamarin.Android.Support.Vector.Drawable.23.3.0\build\Xamarin.Android.Support.Vector.Drawable.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets'))" />
+  </Target>
+  <Import Project="..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Import Project="..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets" Condition="Exists('..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Android.100.1.0\build\MonoAndroid10\Esri.ArcGISRuntime.Xamarin.Android.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Android.csproj
@@ -9,8 +9,8 @@
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Esri.ArcGISRuntime.Xamarin.Forms.Android</RootNamespace>
-    <AssemblyName>Esri.ArcGISRuntime.Xamarin.Forms.Android</AssemblyName>
+    <RootNamespace>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</RootNamespace>
+    <AssemblyName>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Properties/AssemblyInfo.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/Properties/AssemblyInfo.cs
@@ -15,16 +15,17 @@
 //  ******************************************************************************/
 
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Esri.ArcGISRuntime.Toolkit")]
+[assembly: AssemblyTitle("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Esri")]
-[assembly: AssemblyProduct("Esri.ArcGISRuntime.Toolkit")]
+[assembly: AssemblyProduct("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
 [assembly: AssemblyCopyright("Copyright ©Esri 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
+[assembly: ComVisible(false)]

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/packages.config
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Android/packages.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Esri.ArcGISRuntime.Xamarin.Android" version="100.1.0" targetFramework="monoandroid60" />
+  <package id="Esri.ArcGISRuntime.Xamarin.Forms" version="100.1.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.Animated.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.Design" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.v4" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.v7.AppCompat" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.v7.CardView" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.v7.MediaRouter" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.v7.RecyclerView" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Android.Support.Vector.Drawable" version="23.3.0" targetFramework="monoandroid60" />
+  <package id="Xamarin.Forms" version="2.3.4.270" targetFramework="monoandroid60" />
+</packages>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>d3d6aaed-8c2e-4177-b59c-c640e3681b3d</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionMethods.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScaleLine\ScaleLine.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScaleLine\ScaleLineRenderer.cs" />
+	<Compile Include="$(MSBuildThisFileDirectory)..\..\Shared\Properties\buildnum.cs">
+      <Link>Properties\buildnum.cs</Link>
+	</Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Properties\" />
+  </ItemGroup>
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.shproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d3d6aaed-8c2e-4177-b59c-c640e3681b3d</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
@@ -17,10 +17,14 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal
     {
         internal static NativeColor ToNativeColor(this Color color)
         {
+            var a = (byte)(255 * color.A);
+            var r = (byte)(255 * color.R);
+            var g = (byte)(255 * color.G);
+            var b = (byte)(255 * color.B);
 #if NETFX_CORE
-            return NativeColor.FromArgb((byte)color.A, (byte)color.R, (byte)color.G, (byte)color.B);
+            return NativeColor.FromArgb(a, r, g, b);
 #elif __ANDROID__
-            return NativeColor.Argb((int)color.A, (int)color.R, (int)color.G, (int)color.B);
+            return NativeColor.Argb(a, r, g, b);
 #endif
         }
 

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
@@ -1,13 +1,9 @@
 ﻿using Xamarin.Forms;
 #if __ANDROID__
-using NativePoint = Android.Graphics.PointF;
 using NativeColor = Android.Graphics.Color;
 #elif __IOS__
-using NativePoint = CoreGraphics.CGPoint;
+using NativeColor = UIKit.UIColor;
 #elif NETFX_CORE
-using NativePoint = Windows.Foundation.Point;
-#endif
-#if NETFX_CORE
 using NativeColor = Windows.UI.Color;
 using Windows.UI.Xaml.Media;
 #endif
@@ -26,6 +22,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal
             return NativeColor.FromArgb(a, r, g, b);
 #elif __ANDROID__
             return NativeColor.Argb(a, r, g, b);
+#elif __IOS__
+            return NativeColor.FromRGBA(r, g, b, a);
 #endif
         }
 

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms;
+#if __ANDROID__
+using NativePoint = Android.Graphics.PointF;
+using NativeColor = Android.Graphics.Color;
+#elif __IOS__
+using NativePoint = CoreGraphics.CGPoint;
+#elif NETFX_CORE
+using NativePoint = Windows.Foundation.Point;
+#endif
+#if NETFX_CORE
+using NativeColor = Windows.UI.Color;
+#endif
+
+namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal
+{
+    internal static class ExtensionMethods
+    {
+        internal static NativeColor ToNativeColor(this Color color)
+        {
+#if NETFX_CORE
+            return NativeColor.FromArgb((byte)color.A, (byte)color.R, (byte)color.G, (byte)color.B);
+#elif __ANDROID__
+            return NativeColor.Argb((int)color.A, (int)color.R, (int)color.G, (int)color.B);
+#endif
+        }
+
+        internal static Color ToXamarinFormsColor(this NativeColor color)
+        {
+            return Color.FromRgba(color.R, color.G, color.B, color.A);
+        }
+    }
+}

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ExtensionMethods.cs
@@ -9,6 +9,7 @@ using NativePoint = Windows.Foundation.Point;
 #endif
 #if NETFX_CORE
 using NativeColor = Windows.UI.Color;
+using Windows.UI.Xaml.Media;
 #endif
 
 namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal
@@ -28,9 +29,13 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal
 #endif
         }
 
-        internal static Color ToXamarinFormsColor(this NativeColor color)
+        internal static void SetForeground(this UI.Controls.ScaleLine scaleline, NativeColor color)
         {
-            return Color.FromRgba(color.R, color.G, color.B, color.A);
+#if NETFX_CORE
+            scaleline.Foreground = new SolidColorBrush(color);
+#else
+            scaleline.ForegroundColor = color;
+#endif
         }
     }
 }

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Xamarin.Forms;
+using Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal;
+using Esri.ArcGISRuntime.Xamarin.Forms;
+using System.ComponentModel;
+
+namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
+{
+    public class ScaleLine : View
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScaleLine"/> class
+        /// </summary>
+        public ScaleLine() : this(new UI.Controls.ScaleLine()) { }
+
+        internal ScaleLine(UI.Controls.ScaleLine nativeScaleLine)
+        {
+            NativeScaleLine = nativeScaleLine;
+        }
+
+        internal readonly UI.Controls.ScaleLine NativeScaleLine;
+
+        /// <summary>
+        /// Identifies the <see cref="TargetWidth"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty TargetWidthProperty =
+            BindableProperty.Create(nameof(TargetWidth), typeof(double), typeof(ScaleLine), double.NaN, BindingMode.OneWay, null, OnTargetWidthChanged);
+
+        /// <summary>
+        /// Gets or sets the width that will be used to calculate the length of the ScaleLine
+        /// </summary>
+        public double TargetWidth
+        {
+            get { return (double)GetValue(TargetWidthProperty); }
+            set { SetValue(TargetWidthProperty, value); }
+        }
+
+        private static void OnTargetWidthChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var nativeView = ((ScaleLine)bindable).NativeScaleLine;
+            if (nativeView != null)
+                nativeView.TargetWidth = newValue != null ? (double)newValue : nativeView.TargetWidth;
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="MapView"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty MapViewProperty =
+            BindableProperty.CreateAttached(nameof(MapView), typeof(MapView), typeof(ScaleLine), null, BindingMode.OneWay, null, OnMapViewChanged);
+
+        /// <summary>
+        /// Sets the MapView attached property that can be attached to a ScaleLine control to accurately set the scale, instead of
+        /// setting the <see cref="ScaleLine.MapScale"/> property directly.
+        /// </summary>
+        /// <param name="scaleLine">The scaleline control this would be attached to</param>
+        /// <param name="mapView">The mapview to calculate the scale for</param>
+        public static void SetMapView(BindableObject scaleline, MapView mapView)
+        {
+            scaleline.SetValue(MapViewProperty, mapView);
+        }
+
+        /// <summary>
+        /// Gets the MapView attached property that can be attached to a ScaleLine control to accurately set the scale, instead of
+        /// setting the <see cref="ScaleLine.MapScale"/> property directly.
+        /// </summary>
+        /// <param name="scaleLine">The scaleline control this would be attached to</param>
+        /// <returns>The MapView the scaleline is associated with.</returns>
+        public static MapView GetMapView(BindableObject scaleline)
+        {
+            return scaleline.GetValue(MapViewProperty) as MapView;
+        }
+
+        private static void OnMapViewChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var scaleline = (ScaleLine)bindable;
+            var inpc = oldValue as INotifyPropertyChanged;
+            if (inpc != null)
+            {
+                inpc.PropertyChanged -= scaleline.MapView_PropertyChanged;
+            }
+
+            inpc = newValue as INotifyPropertyChanged;
+            if (inpc != null)
+            {
+                inpc.PropertyChanged += scaleline.MapView_PropertyChanged;
+            }
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="MapScale"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty MapScaleProperty =
+            BindableProperty.Create(nameof(MapScale), typeof(double), typeof(ScaleLine), double.NaN, BindingMode.OneWay, null, OnMapScaleChanged);
+
+        /// <summary>
+        /// Gets or sets the scale that the ScaleLine will
+        /// use to calculate scale in metric and imperial units.
+        /// </summary>
+        /// <seealso cref="SetMapView"/>
+        /// <seealso cref="MapViewProperty"/>
+        public double MapScale
+        {
+            get { return (double)GetValue(MapScaleProperty); }
+            set { SetValue(MapScaleProperty, value); }
+        }
+
+        private static void OnMapScaleChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var nativeView = ((ScaleLine)bindable).NativeScaleLine;
+            if (nativeView != null)
+                nativeView.MapScale = newValue != null ? (double)newValue : nativeView.MapScale;
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Foreground"/> bindable property.
+        /// </summary>
+        public static readonly BindableProperty ForegroundProperty =
+            BindableProperty.Create(nameof(Foreground), typeof(Color), typeof(ScaleLine), Color.Black, BindingMode.OneWay, null, OnForegroundChanged);
+
+        /// <summary>
+        /// Gets or sets the foreground color.
+        /// </summary>
+        public Color Foreground
+        {
+            get { return (Color)GetValue(ForegroundProperty); }
+            set { SetValue(ForegroundProperty, value); }
+        }
+
+        private static void OnForegroundChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var nativeView = ((ScaleLine)bindable).NativeScaleLine;
+            if (nativeView != null)
+                nativeView.ForegroundColor = newValue != null ? ((Color)newValue).ToNativeColor() : nativeView.ForegroundColor;
+        }
+
+        private void MapView_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            var view = GetMapView(this);
+            if ((e.PropertyName == nameof(MapView.VisibleArea) || e.PropertyName == nameof(MapView.IsNavigating)) && !view.IsNavigating)
+            {
+                MapScale = CalculateScale(view.VisibleArea, view.UnitsPerPixel);
+            }
+        }
+
+        /// <summary>
+        /// Calculates the scale at the center of a polygon, at a given pixel size
+        /// </summary>
+        /// <remarks>
+        /// A pixel is a device independent logical pixel - ie 1/96 inches.
+        /// </remarks>
+        /// <param name="visibleArea">The area which center the scale will be calculated for.</param>
+        /// <param name="unitsPerPixel">The size of a device indepedent pixel in the units of the spatial reference</param>
+        /// <returns>The MapScale for the center of the view</returns>
+        public static double CalculateScale(Esri.ArcGISRuntime.Geometry.Polygon visibleArea, double unitsPerPixel)
+        {
+            if (visibleArea == null)
+            {
+                return double.NaN;
+            }
+
+            if (visibleArea.SpatialReference == null)
+            {
+                return double.NaN;
+            }
+
+            if (double.IsNaN(unitsPerPixel) || unitsPerPixel <= 0)
+            {
+                return double.NaN;
+            }
+
+            var center = visibleArea.Extent.GetCenter();
+            var centerOnePixelOver = new Geometry.MapPoint(center.X + unitsPerPixel, center.Y, center.SpatialReference);
+
+            // Calculate the geodedetic distance between two points one 'pixel' apart
+            var result = Geometry.GeometryEngine.DistanceGeodetic(center, centerOnePixelOver, Geometry.LinearUnits.Inches, Geometry.AngularUnits.Degrees, Geometry.GeodeticCurveType.Geodesic);
+            double distanceInInches = result.Distance;
+            return distanceInInches * 96;
+        }
+    }
+}

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
@@ -44,9 +44,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
 
         private static void OnTargetWidthChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            var nativeView = ((ScaleLine)bindable).NativeScaleLine;
             if (newValue != null)
-                nativeView.TargetWidth = (double)newValue;
+            {
+                var scaleline = (ScaleLine)bindable;
+                scaleline.NativeScaleLine.TargetWidth = (double)newValue;
+                scaleline.InvalidateMeasure();
+            }
         }
 
         /// <summary>
@@ -113,9 +116,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
 
         private static void OnMapScaleChanged(BindableObject bindable, object oldValue, object newValue)
         {
-            var nativeView = ((ScaleLine)bindable).NativeScaleLine;
             if (newValue != null)
-                nativeView.MapScale = (double)newValue;
+            {
+                var scaleline = (ScaleLine)bindable;
+                scaleline.NativeScaleLine.MapScale = (double)newValue;
+                scaleline.InvalidateMeasure();
+            }
         }
 
         /// <summary>
@@ -148,7 +154,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
                 if (mapView.IsNavigating)
                     return;
                 MapScale = CalculateScale(mapView.VisibleArea, mapView.UnitsPerPixel);
-                InvalidateMeasure();
             }
         }
 

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLine.cs
@@ -19,6 +19,10 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         internal ScaleLine(UI.Controls.ScaleLine nativeScaleLine)
         {
             NativeScaleLine = nativeScaleLine;
+
+#if NETFX_CORE
+            nativeScaleLine.SizeChanged += (o, e) => InvalidateMeasure();
+#endif
         }
 
         internal readonly UI.Controls.ScaleLine NativeScaleLine;
@@ -41,8 +45,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         private static void OnTargetWidthChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var nativeView = ((ScaleLine)bindable).NativeScaleLine;
-            if (nativeView != null)
-                nativeView.TargetWidth = newValue != null ? (double)newValue : nativeView.TargetWidth;
+            if (newValue != null)
+                nativeView.TargetWidth = (double)newValue;
         }
 
         /// <summary>
@@ -110,8 +114,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         private static void OnMapScaleChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var nativeView = ((ScaleLine)bindable).NativeScaleLine;
-            if (nativeView != null)
-                nativeView.MapScale = newValue != null ? (double)newValue : nativeView.MapScale;
+            if (newValue != null)
+                nativeView.MapScale = (double)newValue;
         }
 
         /// <summary>
@@ -132,16 +136,19 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         private static void OnForegroundChanged(BindableObject bindable, object oldValue, object newValue)
         {
             var nativeView = ((ScaleLine)bindable).NativeScaleLine;
-            if (nativeView != null)
-                nativeView.ForegroundColor = newValue != null ? ((Color)newValue).ToNativeColor() : nativeView.ForegroundColor;
+            if (newValue != null)
+                nativeView.SetForeground(((Color)newValue).ToNativeColor());
         }
 
         private void MapView_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            var view = GetMapView(this);
-            if ((e.PropertyName == nameof(MapView.VisibleArea) || e.PropertyName == nameof(MapView.IsNavigating)) && !view.IsNavigating)
+            if ((e.PropertyName == nameof(MapView.VisibleArea) || e.PropertyName == nameof(MapView.IsNavigating)))
             {
-                MapScale = CalculateScale(view.VisibleArea, view.UnitsPerPixel);
+                var mapView = GetMapView(this);
+                if (mapView.IsNavigating)
+                    return;
+                MapScale = CalculateScale(mapView.VisibleArea, mapView.UnitsPerPixel);
+                InvalidateMeasure();
             }
         }
 

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLineRenderer.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/Shared/ScaleLine/ScaleLineRenderer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+#if __ANDROID__
+using Xamarin.Forms.Platform.Android;
+#elif __IOS__
+using Xamarin.Forms.Platform.iOS;
+#elif NETFX_CORE
+using Xamarin.Forms.Platform.UWP;
+#endif
+
+[assembly: ExportRenderer(typeof(Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.ScaleLine), typeof(Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.ScaleLineRenderer))]
+namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
+{
+    internal class ScaleLineRenderer : ViewRenderer<ScaleLine, Esri.ArcGISRuntime.Toolkit.UI.Controls.ScaleLine>
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<ScaleLine> e)
+        {
+            base.OnElementChanged(e);
+
+            if (Control == null)
+            {
+                SetNativeControl(e.NewElement?.NativeScaleLine);
+            }
+        }
+
+#if !NETFX_CORE
+        /// <summary>
+        /// Determines whether the native control is disposed of when this renderer is disposed
+        /// Can be overridden in deriving classes (default: true).
+        /// </summary>
+        protected override bool ManageNativeControlLifetime => false;
+#endif
+    }
+}

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.UWP.csproj
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{789DFC6B-E631-4002-90A4-CA6609DB4CAE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</RootNamespace>
+    <AssemblyName>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.15063.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="Properties\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Forms">
+      <Version>100.1.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>5.4.0</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>2.3.4.270</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\UWP\Esri.ArcGISRuntime.Toolkit.UWP.csproj">
+      <Project>{3596c206-41c8-4405-a5c7-382e79e8d091}</Project>
+      <Name>Esri.ArcGISRuntime.Toolkit.UWP</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems" Label="Shared" />
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Properties/AssemblyInfo.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Properties/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2016 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Esri")]
+[assembly: AssemblyProduct("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
+[assembly: AssemblyCopyright("Copyright ©Esri 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Properties/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.rd.xml
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/UWP/Properties/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.rd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file contains Runtime Directives, specifications about types your application accesses
+    through reflection and other dynamic code patterns. Runtime Directives are used to control the
+    .NET Native optimizer and ensure that it does not remove code accessed by your library. If your
+    library does not do any reflection, then you generally do not need to edit this file. However,
+    if your library reflects over types, especially types passed to it or derived from its types,
+    then you should write Runtime Directives.
+
+    The most common use of reflection in libraries is to discover information about types passed
+    to the library. Runtime Directives have three ways to express requirements on types passed to
+    your library.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Use these directives to reflect over types passed as a parameter.
+
+    2.  SubTypes
+        Use a SubTypes directive to reflect over types derived from another type.
+
+    3.  AttributeImplies
+        Use an AttributeImplies directive to indicate that your library needs to reflect over
+        types or methods decorated with an attribute.
+
+    For more information on writing Runtime Directives for libraries, please visit
+    https://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms">
+
+  	<!-- add directives for your library here -->
+
+  </Library>
+</Directives>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.iOS.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.iOS.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A3C4F5ED-A5BF-4FAC-9D20-9B4222578333}</ProjectGuid>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</AssemblyName>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Esri.ArcGISRuntime, Version=100.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.1.0\lib\Xamarin.iOS10\Esri.ArcGISRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="Esri.ArcGISRuntime.Xamarin.Forms, Version=100.1.0.0, Culture=neutral, PublicKeyToken=8fc3cc631e44ad86, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.Forms.100.1.0\lib\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.Forms.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTK-1.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.iOS, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Xamarin.Forms.2.3.4.270\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\iOS\Esri.ArcGISRuntime.Toolkit.iOS.csproj">
+      <Project>{b845a5fb-b7bd-4085-867e-e44bf36af5ab}</Project>
+      <Name>Esri.ArcGISRuntime.Toolkit.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\Shared\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Xamarin.Forms.2.3.4.270\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.1.0\build\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.iOS.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.1.0\build\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.iOS.targets'))" />
+  </Target>
+  <Import Project="..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.1.0\build\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.iOS.targets" Condition="Exists('..\..\..\..\packages\Esri.ArcGISRuntime.Xamarin.iOS.100.1.0\build\Xamarin.iOS10\Esri.ArcGISRuntime.Xamarin.iOS.targets')" />
+</Project>

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/Properties/AssemblyInfo.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2016 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Esri")]
+[assembly: AssemblyProduct("Esri.ArcGISRuntime.Toolkit.Xamarin.Forms")]
+[assembly: AssemblyCopyright("Copyright ©Esri 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a3c4f5ed-a5bf-4fac-9d20-9b4222578333")]

--- a/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/packages.config
+++ b/src/Esri.ArcGISRuntime.Toolkit/XamarinForms/iOS/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Esri.ArcGISRuntime.Xamarin.Forms" version="100.1.0" targetFramework="xamarinios10" />
+  <package id="Esri.ArcGISRuntime.Xamarin.iOS" version="100.1.0" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="2.3.4.270" targetFramework="xamarinios10" />
+</packages>

--- a/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/RectangleView.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/RectangleView.cs
@@ -71,6 +71,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
 
         public override CGSize IntrinsicContentSize => _size;
 
+        public override CGSize SizeThatFits(CGSize size)
+        {
+            var widthThatFits = Math.Min(size.Width, IntrinsicContentSize.Width);
+            var heightThatFits = Math.Min(size.Height, IntrinsicContentSize.Height);
+            return new CGSize(widthThatFits, heightThatFits);
+        }
+
         /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged" />
         public event PropertyChangedEventHandler PropertyChanged;
 


### PR DESCRIPTION
Adds implementations of the `ScaleLine` component for Xamarin Android and Xamarin Forms.  Changes include:

- Addition of Xamarin Android, Xamarin Forms iOS, Xamarin Forms Android, Xamarin Forms UWP, and Xamarin Forms shared toolkit projects
- Xamarin Android implementation of `ScaleLine` logic
- Xamarin Forms implementation of `ScaleLine` that leverages native implementations
- Tweaks to native Xamarin iOS `ScaleLine` implementation to support Forms