### PR TITLE
Turn off use-latest for Android build

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
+++ b/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.Android/Toolkit.Samples.Forms.Android.csproj
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.Android/Toolkit.Samples.Forms.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>


### PR DESCRIPTION
Turn off use-latest for Android build to keep builds predictable and avoid csproj contents changing automatically.