### PR TITLE
setting ReferenceOutputAssembly to false

### DIFF
--- a/src/Esri.ArcGISRuntime.Toolkit.Preview/Common/Esri.ArcGISRuntime.Toolkit.Preview.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit.Preview/Common/Esri.ArcGISRuntime.Toolkit.Preview.csproj
@@ -88,8 +88,7 @@
  
   <ItemGroup>
     <ProjectReference Include="..\..\Esri.ArcGISRuntime.Toolkit\Esri.ArcGISRuntime.Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
-      <Private>false</Private>
-      <PrivateAssets>analyzers;contentFiles</PrivateAssets>
+	    <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
If this doesn't work we might have to remove the project reference altogether and switch to PackageReference