### PR TITLE
Project settings clean up

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <!--Common package properties-->
     <Authors>Esri Inc.</Authors>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageIconUrl>http://links.esri.com/dotnetsdklogo</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Esri/arcgis-toolkit-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/Esri/arcgis-toolkit-dotnet/master/license.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>    
     <PackageReleaseNotes>v100.4: https://github.com/Esri/arcgis-toolkit-dotnet/releases/tag/v100.4.0</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/Esri/arcgis-toolkit-dotnet</RepositoryUrl>
-    <RepositoryType></RepositoryType>
+	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Copyright>Copyright © 2014-2018 Esri.</Copyright>
 
     <DefaultLanguage>en-US</DefaultLanguage>
@@ -42,9 +42,11 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <OutputPath>$(MSBuildThisFileDirectory)..\Output\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
-      </PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
       <ItemGroup>
         <PackageReference Include="MSBuild.Sdk.Extras" Version="1.5.4" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
       </ItemGroup>
       <ItemGroup>
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)Esri.ArcGISRuntime.Toolkit\stylecop.json" />

--- a/src/Esri.ArcGISRuntime.Toolkit.Preview/Common/Esri.ArcGISRuntime.Toolkit.Preview.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit.Preview/Common/Esri.ArcGISRuntime.Toolkit.Preview.csproj
@@ -9,10 +9,6 @@
     <AssemblyName>Esri.ArcGISRuntime.Toolkit.Preview</AssemblyName>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-	  <!-- Work around MSBuild bug when building from comandline: https://github.com/Microsoft/msbuild/issues/2274 -->
-    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(UWPTargetFramework)'">

--- a/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
@@ -9,10 +9,6 @@
     <RootNamespace>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</RootNamespace>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <!-- Work around MSBuild bug when building from commandline: https://github.com/Microsoft/msbuild/issues/2274 -->
-    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(UWPTargetFramework)'">

--- a/src/Esri.ArcGISRuntime.Toolkit/Common/Esri.ArcGISRuntime.Toolkit.csproj
+++ b/src/Esri.ArcGISRuntime.Toolkit/Common/Esri.ArcGISRuntime.Toolkit.csproj
@@ -9,10 +9,6 @@
     <AssemblyName>Esri.ArcGISRuntime.Toolkit</AssemblyName>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-	  <!-- Work around MSBuild bug when building from comandline: https://github.com/Microsoft/msbuild/issues/2274 -->
-    <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
-	<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == '$(UWPTargetFramework)'">


### PR DESCRIPTION
Clean up package settings, use source linking and remove workaround for commandline build now fixed in Update 9