### PR TITLE
Compass fixes

### DIFF
--- a/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Compass/Compass.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Compass/Compass.cs
@@ -16,9 +16,9 @@
 
 using System;
 using System.ComponentModel;
+using Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal;
 using Esri.ArcGISRuntime.Xamarin.Forms;
 using Xamarin.Forms;
-using Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.Internal;
 
 namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
 {
@@ -44,6 +44,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
             NativeCompass = nativeCompass;
             HorizontalOptions = LayoutOptions.End;
             VerticalOptions = LayoutOptions.Start;
+            WidthRequest = 30;
+            HeightRequest = 30;
 #if NETFX_CORE
             nativeCompass.SizeChanged += (o, e) => InvalidateMeasure();
             nativeCompass.RegisterPropertyChangedCallback(UI.Controls.Compass.HeadingProperty, (d, e) => UpdateHeadingFromNativeCompass());
@@ -142,5 +144,39 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
 #endif
             compass._headingSetByNativeControl = false;
         }
+
+#if __IOS__
+        private UIKit.NSLayoutConstraint _widthConstraint;
+        private UIKit.NSLayoutConstraint _heightConstraint;
+
+        /// <inheritdoc />
+        protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+        {
+            if (_widthConstraint != null)
+            {
+                _widthConstraint.Active = false;
+            }
+
+            if (_heightConstraint != null)
+            {
+                _heightConstraint.Active = false;
+            }
+
+            _widthConstraint = NativeCompass.WidthAnchor.ConstraintEqualTo((nfloat)widthConstraint);
+            _heightConstraint = NativeCompass.WidthAnchor.ConstraintEqualTo((nfloat)heightConstraint);
+
+            if (_widthConstraint != null)
+            {
+                _widthConstraint.Active = true;
+            }
+
+            if (_heightConstraint != null)
+            {
+                _heightConstraint.Active = true;
+            }
+
+            return base.OnMeasure(widthConstraint, heightConstraint);
+        }
+#endif
     }
 }

--- a/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Compass/Compass.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms/Compass/Compass.cs
@@ -41,7 +41,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         internal Compass(UI.Controls.Compass nativeCompass)
         {
             NativeCompass = nativeCompass;
-
+            HorizontalOptions = LayoutOptions.End;
+            VerticalOptions = LayoutOptions.Start;
 #if NETFX_CORE
             nativeCompass.SizeChanged += (o, e) => InvalidateMeasure();
 #endif

--- a/src/Esri.ArcGISRuntime.Toolkit/Common/UI/Controls/Compass/Compass.Xamarin.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/Common/UI/Controls/Compass/Compass.Xamarin.cs
@@ -17,11 +17,12 @@
 #if XAMARIN
 
 using System;
+using System.ComponentModel;
 using Esri.ArcGISRuntime.UI.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    public partial class Compass
+    public partial class Compass : System.ComponentModel.INotifyPropertyChanged
     {
         private double _heading;
 
@@ -37,6 +38,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
                 _heading = value;
                 UpdateCompassRotation(true);
+                OnPropertyChanged(nameof(Heading));
             }
         }
 
@@ -49,6 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 _autoHide = value;
                 SetVisibility(!(value && _heading == 0));
+                OnPropertyChanged(nameof(AutoHide));
             }
         }
 
@@ -66,8 +69,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 var oldView = _geoView;
                 _geoView = value;
                 WireGeoViewPropertyChanged(oldView, _geoView);
+                OnPropertyChanged(nameof(GeoView));
             }
         }
+
+        private void OnPropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <inheritdoc cref="INotifyPropertyChanged.PropertyChanged" />
+        public event PropertyChangedEventHandler PropertyChanged;
     }
 }
 #endif

--- a/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
@@ -81,6 +81,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         public override CGSize IntrinsicContentSize { get; } = new CGSize(DefaultSize, DefaultSize);
 
         /// <inheritdoc />
+        public override CGSize SizeThatFits(CGSize size)
+        {
+            var size2 = base.SizeThatFits(size);
+            var widthThatFits = Math.Min(size.Width, IntrinsicContentSize.Width);
+            var heightThatFits = Math.Min(size.Height, IntrinsicContentSize.Height);
+            return new CGSize(widthThatFits, heightThatFits);
+        }
+
+        /// <inheritdoc />
         public override void Draw(CGRect rect)
         {
             base.Draw(rect);

--- a/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
@@ -78,17 +78,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         }
 
         /// <inheritdoc />
-        public override CGSize IntrinsicContentSize { get; } = new CGSize(DefaultSize, DefaultSize);
-
-        /// <inheritdoc />
-        public override CGSize SizeThatFits(CGSize size)
-        {
-            var widthThatFits = Math.Min(size.Width, IntrinsicContentSize.Width);
-            var heightThatFits = Math.Min(size.Height, IntrinsicContentSize.Height);
-            return new CGSize(widthThatFits, heightThatFits);
-        }
-
-        /// <inheritdoc />
         public override void Draw(CGRect rect)
         {
             base.Draw(rect);

--- a/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
+++ b/src/Esri.ArcGISRuntime.Toolkit/iOS/UI/Controls/Compass/Compass.iOS.cs
@@ -83,7 +83,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <inheritdoc />
         public override CGSize SizeThatFits(CGSize size)
         {
-            var size2 = base.SizeThatFits(size);
             var widthThatFits = Math.Min(size.Width, IntrinsicContentSize.Width);
             var heightThatFits = Math.Min(size.Height, IntrinsicContentSize.Height);
             return new CGSize(widthThatFits, heightThatFits);


### PR DESCRIPTION
WIP 

Fixes:
 - #222 (Forms Compass doesn't align consistently across platforms) Set default alignment to top-right like the native controls
 - #251 (Forms.Compass control rarely receives click events on Android) Use native click handler instead of duplicating code in Xamarin.Forms (also allows to delete a lot of now unnecessary code)
 - #252 (Compass control not appearing on iOS): Ensure a proper size is calculated
