### PR TITLE
Remove duplicate XML summary doc from partial class declarations

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/LayerLegend/LayerLegend.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/LayerLegend/LayerLegend.Windows.cs
@@ -31,9 +31,6 @@ using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The Legend Control that generates a list of Legend Items for a Layer
-    /// </summary>
     public partial class LayerLegend
     {
         private void Initialize() => DefaultStyleKey = typeof(LayerLegend);

--- a/src/Toolkit/Toolkit/UI/Controls/LayerLegend/LayerLegend.Xamarin.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/LayerLegend/LayerLegend.Xamarin.cs
@@ -20,9 +20,6 @@ using Esri.ArcGISRuntime.Mapping;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The Legend Control that generates a list of Legend Items for a Layer
-    /// </summary>
     public partial class LayerLegend
     {
         private ILayerContent _layerContent;

--- a/src/Toolkit/Toolkit/UI/Controls/LayerList/LayerList.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/LayerList/LayerList.Windows.cs
@@ -30,11 +30,6 @@ using System.Windows.Data;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The base class for <see cref="Legend"/>
-    /// and TableOfContents control is used to display symbology and description for a set of <see cref="Layer"/>s
-    /// in a <see cref="Map"/> or <see cref="Scene"/> contained in a <see cref="Esri.ArcGISRuntime.UI.Controls.GeoView"/>.
-    /// </summary>
     [TemplatePart(Name = "List", Type = typeof(ItemsControl))]
     public partial class LayerList
     {

--- a/src/Toolkit/Toolkit/UI/Controls/LayerList/LayerList.Xamarin.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/LayerList/LayerList.Xamarin.cs
@@ -20,11 +20,6 @@ using Esri.ArcGISRuntime.UI.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The base class for <see cref="Legend"/>
-    /// and TableOfContents control is used to display symbology and description for a set of <see cref="Layer"/>s
-    /// in a <see cref="Map"/> or <see cref="Scene"/> contained in a <see cref="Esri.ArcGISRuntime.UI.Controls.GeoView"/>.
-    /// </summary>
     public partial class LayerList
     {
         private GeoView _geoView;

--- a/src/Toolkit/Toolkit/UI/Controls/Legend/Legend.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/Legend/Legend.Windows.cs
@@ -28,10 +28,6 @@ using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The Legend control is used to display symbology and description for a set of <see cref="Layer"/>s
-    /// in a <see cref="Map"/> or <see cref="Scene"/> contained in a <see cref="GeoView"/>.
-    /// </summary>
     [TemplatePart(Name = "List", Type = typeof(ItemsControl))]
     public partial class Legend
     {

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Windows.cs
@@ -26,11 +26,6 @@ using System.Windows;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The PopupViewer control is used to display details and media, edit attributes, geometry and related records,
-    /// manage attachments of an <see cref="Data.ArcGISFeature"/> or a <see cref="ArcGISRuntime.UI.Graphic"/>
-    /// as defined in its <see cref="Mapping.Popups.Popup"/>.
-    /// </summary>
     public partial class PopupViewer
     {
         private void Initialize() => DefaultStyleKey = GetType();

--- a/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Xamarin.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/PopupViewer/PopupViewer.Xamarin.cs
@@ -19,11 +19,6 @@ using Esri.ArcGISRuntime.Mapping.Popups;
 
 namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 {
-    /// <summary>
-    /// The PopupViewer control is used to display details and media, edit attributes, geometry and related records,
-    /// manage attachments of an <see cref="Data.ArcGISFeature"/> or a <see cref="ArcGISRuntime.UI.Graphic"/>
-    /// as defined in its <see cref="Mapping.Popups.Popup"/>.
-    /// </summary>
     public partial class PopupViewer
     {
         private PopupManager _popupManager;


### PR DESCRIPTION
Removes duplicated XML summary documentation from partial class declarations.  Needed to remove duplication of the documentation in the API reference.