### PR TITLE
Legend: Fix SetGeoView not subscribing to SceneView scene changes

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/Legend/LegendDataSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/Legend/LegendDataSource.cs
@@ -173,7 +173,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #if NETFX_CORE
                     _propertyChangedCallbackToken = sceneview.RegisterPropertyChangedCallback(SceneView.SceneProperty, GeoViewDocumentChanged);
 #else
-                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(MapView)).AddValueChanged(sceneview, GeoViewDocumentChanged);
+                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(SceneView)).AddValueChanged(sceneview, GeoViewDocumentChanged);
 #endif
                 }
 #endif


### PR DESCRIPTION
`LegendDataSource.SetGeoView(...)` tried to find SceneProperty on MapView type instead of on SceneView type.  This caused `DependencyPropertyDescriptor.FromProperty` to create a new "attached" PropertyDescriptor, instead of looking up the correct one.  As a result, GeoViewDocumentChanged listener was not actually called.  This PR fixes the type and event fires as expected.

Problem originally discovered by @nCastle1 