### PR TITLE
Fixes issue with bookmark loading

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BookmarksView/BookmarksViewSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BookmarksView/BookmarksViewSample.xaml.cs
@@ -35,6 +35,8 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.BookmarksView
         public BookmarksViewSample()
         {
             InitializeComponent();
+
+            MyMapView.Map = new Map(new Uri("https://arcgisruntime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2"));
         }
 
         private void SetMapViewBinding_Click(object sender, RoutedEventArgs e)

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/BookmarksView/BookmarksViewSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/BookmarksView/BookmarksViewSample.xaml.cs
@@ -43,6 +43,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.BookmarksView
         public BookmarksViewSample()
         {
             InitializeComponent();
+
+            MyMapView.Map = new Map(new Uri("https://arcgisruntime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2"));
         }
 
         private void SetMapViewBinding_Click(object sender, RoutedEventArgs e)

--- a/src/Toolkit/Toolkit/UI/Controls/BookmarksView/BookmarksViewDataSource.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BookmarksView/BookmarksViewDataSource.cs
@@ -164,11 +164,11 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
                 }
 #else
-                // Handle case where geoview loads map while events are being set up
-                GeoViewDocumentChanged(null, null);
 
                 (_geoView as INotifyPropertyChanged).PropertyChanged += GeoView_PropertyChanged;
 #endif
+                // Handle case where geoview loads map while events are being set up
+                GeoViewDocumentChanged(null, null);
             }
         }
 


### PR DESCRIPTION
Sometimes, when the Map is set on a MapView, the map property change event happens before it can be subscribed to. To work around this, Xamarin platforms were attempting to load the map in all cases when the geoview is set. That step is also required on UWP (and probably WPF), but it was missed because of a deficiency in the bookmarks tests for UWP & WPF.

This PR fixes that issue and updates the test so that the original issue would have been found.