### PR TITLE
iOS usability improvements

### DIFF
--- a/docs/bookmarks-view.md
+++ b/docs/bookmarks-view.md
@@ -1,6 +1,6 @@
 # BookmarksView
 
-### Features:
+## Features
 
 * Associate the bookmarks control with a `MapView` or `SceneView` (`GeoView` property), through binding on supported platforms (WPF, UWP, Forms) or plain properties otherwise.
 * Display a list of bookmarks, defined by the `Map` or `Scene` from the associated `GeoView` or the `BookmarksOverride` if set.
@@ -66,6 +66,135 @@ public partial class BookmarksMapEventTestController : UIViewController
             _bookmarksView.View.BottomAnchor.ConstraintEqualTo(View.BottomAnchor).Active = true;
         }
     }
+```
+
+To show modally in a way that works well on iPad and iPhone:
+
+```cs
+public partial class BookmarksModalSampleViewController : UIViewController
+{
+    // Hold references to UI controls.
+    private MapView _myMapView;
+    private BookmarksView _bookmarksView;
+    private UIBarButtonItem _showBookmarksButton;
+
+    public BookmarksModalSampleViewController()
+    {
+        Title = "Show bookmarks modally";
+    }
+
+    private void Initialize()
+    {
+        // Create and show the map.
+        _myMapView.Map = new Map(new Uri("https://arcgisruntime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2"));
+    }
+
+    public override void LoadView()
+    {
+        // Create the views.
+        View = new UIView() { BackgroundColor = UIColor.White };
+
+        _myMapView = new MapView();
+        _myMapView.TranslatesAutoresizingMaskIntoConstraints = false;
+
+        _bookmarksView = new BookmarksView();
+        _bookmarksView.GeoView = _myMapView;
+
+        _showBookmarksButton = new UIBarButtonItem(UIBarButtonSystemItem.Bookmarks);
+
+        // Note: this won't work if there's no navigation controller.
+        NavigationItem.RightBarButtonItem = _showBookmarksButton;
+
+        // Add the views.
+        View.AddSubviews(_myMapView);
+
+        // Lay out the views.
+        NSLayoutConstraint.ActivateConstraints(new[]{
+            _myMapView.TopAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TopAnchor),
+            _myMapView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor),
+            _myMapView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+            _myMapView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor)
+        });
+    }
+
+    private void _bookmarksView_BookmarkSelected(object sender, Bookmark e)
+    {
+        DismissModalViewController(true);
+    }
+
+    private void ShowBookmarks_Clicked(object sender, EventArgs e)
+    {
+        // Note: BookmarksView is a UIViewController.
+        // This shows bookmarks modally on iPhone, in a popover on iPad
+        _bookmarksView.ModalPresentationStyle = UIModalPresentationStyle.Popover;
+        if (_bookmarksView.PopoverPresentationController is UIPopoverPresentationController popoverPresentationController)
+        {
+            popoverPresentationController.Delegate = new ppDelegate();
+            popoverPresentationController.BarButtonItem = _showBookmarksButton;
+        }
+        // Attempting to show a VC while it is already being presented is an issue (can happen with rapid tapping)
+        try
+        {
+            PresentModalViewController(_bookmarksView, true);
+        }
+        catch (MonoTouchException ex)
+        {
+            System.Diagnostics.Debug.WriteLine(ex);
+            // Ignore
+        }
+    }
+
+    /// <summary>
+    /// Helper class, used to ensure modal appears properly for each presentation style
+    /// </summary>
+    private class ppDelegate : UIPopoverPresentationControllerDelegate
+    {
+        public override UIViewController GetViewControllerForAdaptivePresentation(UIPresentationController controller, UIModalPresentationStyle style)
+        {
+            return new UINavigationController(controller.PresentedViewController);
+        }
+    }
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+        Initialize();
+    }
+
+    public override void ViewWillAppear(bool animated)
+    {
+        base.ViewWillAppear(animated);
+
+        if (_showBookmarksButton != null)
+        {
+            _showBookmarksButton.Clicked -= ShowBookmarks_Clicked;
+            _showBookmarksButton.Clicked += ShowBookmarks_Clicked;
+        }
+
+        if (_bookmarksView != null)
+        {
+            // Listen for bookmark selections so that the view can be dismissed.
+            _bookmarksView.BookmarkSelected -= _bookmarksView_BookmarkSelected;
+            _bookmarksView.BookmarkSelected += _bookmarksView_BookmarkSelected;
+        }
+    }
+
+    public override void ViewDidDisappear(bool animated)
+    {
+        base.ViewDidDisappear(animated);
+
+        // unsub from events to prevent leaks
+        if (_showBookmarksButton != null)
+        {
+            _showBookmarksButton.Clicked -= ShowBookmarks_Clicked;
+        }
+
+        if (_bookmarksView != null)
+        {
+            _bookmarksView.BookmarkSelected -= _bookmarksView_BookmarkSelected;
+        }
+    }
+}
 ```
 
 ### Android

--- a/src/Samples/Toolkit.SampleApp.iOS/Samples/BookmarksView/BookmarksModalSampleViewController.cs
+++ b/src/Samples/Toolkit.SampleApp.iOS/Samples/BookmarksView/BookmarksModalSampleViewController.cs
@@ -1,0 +1,135 @@
+﻿using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI.Controls;
+using Foundation;
+using System;
+using UIKit;
+
+namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples
+{
+    [SampleInfoAttribute(Category = "BookmarksView", DisplayName = "BookmarksView - Modal presentation", Description = "Demonstrates modal usage - great on iPad and iPhone.")]
+    public partial class BookmarksModalSampleViewController : UIViewController
+    {
+        // Hold references to UI controls.
+        private MapView _myMapView;
+        private BookmarksView _bookmarksView;
+        private UIBarButtonItem _showBookmarksButton;
+
+        public BookmarksModalSampleViewController()
+        {
+            Title = "Show bookmarks modally";
+        }
+
+        private void Initialize()
+        {
+            // Create and show the map.
+            _myMapView.Map = new Map(new Uri("https://arcgisruntime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2"));
+        }
+
+        public override void LoadView()
+        {
+            // Create the views.
+            View = new UIView() { BackgroundColor = UIColor.White };
+
+            _myMapView = new MapView();
+            _myMapView.TranslatesAutoresizingMaskIntoConstraints = false;
+
+            _bookmarksView = new BookmarksView();
+            _bookmarksView.GeoView = _myMapView;
+
+            _showBookmarksButton = new UIBarButtonItem(UIBarButtonSystemItem.Bookmarks);
+
+            // Note: this won't work if there's no navigation controller.
+            NavigationItem.RightBarButtonItem = _showBookmarksButton;
+
+            // Add the views.
+            View.AddSubviews(_myMapView);
+
+            // Lay out the views.
+            NSLayoutConstraint.ActivateConstraints(new[]{
+                _myMapView.TopAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TopAnchor),
+                _myMapView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor),
+                _myMapView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+                _myMapView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor)
+            });
+        }
+
+        private void _bookmarksView_BookmarkSelected(object sender, Bookmark e)
+        {
+            DismissModalViewController(true);
+        }
+
+        private void ShowBookmarks_Clicked(object sender, EventArgs e)
+        {
+            // Note: BookmarksView is a UIViewController.
+            // This shows bookmarks modally on iPhone, in a popover on iPad
+            _bookmarksView.ModalPresentationStyle = UIModalPresentationStyle.Popover;
+            if (_bookmarksView.PopoverPresentationController is UIPopoverPresentationController popoverPresentationController)
+            {
+                popoverPresentationController.Delegate = new ppDelegate();
+                popoverPresentationController.BarButtonItem = _showBookmarksButton;
+            }
+            // Attempting to show a VC while it is already being presented is an issue (can happen with rapid tapping)
+            try
+            {
+                PresentModalViewController(_bookmarksView, true);
+            }
+            catch (MonoTouchException ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex);
+                // Ignore
+            }
+        }
+
+        /// <summary>
+        /// Helper class, used to ensure modal appears properly for each presentation style
+        /// </summary>
+        private class ppDelegate : UIPopoverPresentationControllerDelegate
+        {
+            public override UIViewController GetViewControllerForAdaptivePresentation(UIPresentationController controller, UIModalPresentationStyle style)
+            {
+                return new UINavigationController(controller.PresentedViewController);
+            }
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            Initialize();
+        }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
+
+            if (_showBookmarksButton != null)
+            {
+                _showBookmarksButton.Clicked -= ShowBookmarks_Clicked;
+                _showBookmarksButton.Clicked += ShowBookmarks_Clicked;
+            }
+
+            if (_bookmarksView != null)
+            {
+                // Listen for bookmark selections so that the view can be dismissed.
+                _bookmarksView.BookmarkSelected -= _bookmarksView_BookmarkSelected;
+                _bookmarksView.BookmarkSelected += _bookmarksView_BookmarkSelected;
+            }
+        }
+
+        public override void ViewDidDisappear(bool animated)
+        {
+            base.ViewDidDisappear(animated);
+
+            // unsub from events to prevent leaks
+            if (_showBookmarksButton != null)
+            {
+                _showBookmarksButton.Clicked -= ShowBookmarks_Clicked;
+            }
+
+            if (_bookmarksView != null)
+            {
+                _bookmarksView.BookmarkSelected -= _bookmarksView_BookmarkSelected;
+            }
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.iOS/SamplesViewController.cs
+++ b/src/Samples/Toolkit.SampleApp.iOS/SamplesViewController.cs
@@ -49,7 +49,15 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp
                 Sample item = _data[indexPath.Row];
                 cell.TextLabel.Text = item.Name;
                 cell.DetailTextLabel.Text = item.Description;
-                cell.DetailTextLabel.TextColor = UIColor.SecondaryLabelColor;
+                if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+                {
+                    cell.DetailTextLabel.TextColor = UIColor.SecondaryLabelColor;
+                }
+                else
+                {
+                    cell.DetailTextLabel.TextColor = UIColor.Gray;
+                }
+                
                 cell.Accessory = UITableViewCellAccessory.DisclosureIndicator;
                 return cell;
             }

--- a/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
+++ b/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
@@ -66,6 +66,7 @@
     <Compile Include="SamplesViewController.designer.cs">
       <DependentUpon>SamplesViewController.cs</DependentUpon>
     </Compile>
+    <Compile Include="Samples\BookmarksView\BookmarksModalSampleViewController.cs" />
     <Compile Include="Samples\BookmarksView\BookmarksMapEventTestController.cs" />
     <Compile Include="Samples\BookmarksView\BookmarksViewSceneViewViewController.cs" />
     <Compile Include="Samples\LayerLegendViewController.cs" />

--- a/src/Toolkit/Toolkit.iOS/UI/Controls/BookmarksView/BookmarksView.iOS.cs
+++ b/src/Toolkit/Toolkit.iOS/UI/Controls/BookmarksView/BookmarksView.iOS.cs
@@ -73,10 +73,9 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 _listView.BottomAnchor.ConstraintEqualTo(View.BottomAnchor)
             });
 
-            if (NavigationItem != null)
+            // Set a title if not already set
+            if (NavigationItem != null && string.IsNullOrEmpty(Title))
             {
-                _closeButton = new UIBarButtonItem("Close", UIBarButtonItemStyle.Plain, null);
-                NavigationItem.RightBarButtonItem = _closeButton;
                 Title = "Bookmarks";
             }
 


### PR DESCRIPTION
This PR makes the following changes:

* Checks for iOS 13 before using named system color in the main samples listview - needed to enable testing iOS 12
* Removes the 'close' button from the iOS bookmarks view - the pattern should be that the user provides that in their own code, if they want it. On iOS 13, it is not needed by default.
* Adds doc & a sample for showing bookmarks modally - there are some extra steps needed on iOS to ensure a great experience across both iPad and iPhone.