### PR TITLE
Moved common layer-tracking code to common class

### DIFF
--- a/src/Toolkit.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
+++ b/src/Toolkit.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\Toolkit\Toolkit\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
     <Compile Include="..\Toolkit\Toolkit\UI\Controls\Legend\LegendDataSource.cs" Link="Legend\LegendDataSource.cs" />
     <Compile Include="..\Toolkit\Toolkit\UI\Controls\BookmarksView\BookmarksViewDataSource.cs" Link="BookmarksView\BookmarksViewDataSource.cs" />
+    <Compile Include="..\Toolkit\Toolkit\UI\LayerContentDataSource.cs" Link="LayerContentDataSource.cs" />
     <Compile Include="..\Toolkit\Toolkit\WeakEventListener.cs" Link="WeakEventListener.cs" />
   </ItemGroup>
 

--- a/src/Toolkit.Preview/Toolkit.Preview/Esri.ArcGISRuntime.Toolkit.Preview.csproj
+++ b/src/Toolkit.Preview/Toolkit.Preview/Esri.ArcGISRuntime.Toolkit.Preview.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Include="..\..\Toolkit\Toolkit\UI\LayerContentDataSource.cs" Link="UI\TableOfContents\LayerContentDataSource.cs" />
     <Compile Include="..\..\Toolkit\Toolkit\WeakEventListener.cs" Link="WeakEventListener.cs" />
   </ItemGroup>
  

--- a/src/Toolkit.Preview/Toolkit.Preview/UI/TableOfContents/TocDataSource.cs
+++ b/src/Toolkit.Preview/Toolkit.Preview/UI/TableOfContents/TocDataSource.cs
@@ -43,15 +43,11 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
 #if NETFX_CORE
     [Windows.UI.Xaml.Data.Bindable]
 #endif
-    internal class TocDataSource : IList<TocItem>, INotifyCollectionChanged, INotifyPropertyChanged, IList
+    internal class TocDataSource : LayerContentDataSource<TocItem>
     {
-        private List<TocItem> _items = new List<TocItem>();
-        private GeoView _geoview;
-        private DependencyObject _owner;
-
         public TocDataSource(DependencyObject owner)
+            : base(owner)
         {
-            _owner = owner;
             _showLegend = true;
         }
 
@@ -65,9 +61,9 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
                 if (_showLegend != value)
                 {
                     _showLegend = value;
-                    if (_items != null)
+                    if (Items != null)
                     {
-                        foreach (var item in _items)
+                        foreach (var item in Items)
                         {
                             item.ShowLegend = value;
                         }
@@ -76,275 +72,28 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
             }
         }
 
-#if NETFX_CORE && !XAMARIN_FORMS
-        private long _propertyChangedCallbackToken = 0;
-#endif
-
-        internal void SetGeoView(GeoView geoview)
-        {
-            if (geoview == _geoview)
-            {
-                return;
-            }
-
-            if (_geoview != null)
-            {
-#if XAMARIN || XAMARIN_FORMS
-                (_geoview as INotifyPropertyChanged).PropertyChanged -= GeoView_PropertyChanged;
-#else
-                if (_geoview is MapView mapview)
-                {
-#if NETFX_CORE
-                    mapview.UnregisterPropertyChangedCallback(MapView.MapProperty, _propertyChangedCallbackToken);
-#else
-                    DependencyPropertyDescriptor.FromProperty(MapView.MapProperty, typeof(MapView)).RemoveValueChanged(mapview, GeoViewDocumentChanged);
-#endif
-                }
-                else if (_geoview is SceneView sceneview)
-                {
-#if NETFX_CORE
-                    sceneview.UnregisterPropertyChangedCallback(SceneView.SceneProperty, _propertyChangedCallbackToken);
-#else
-                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(SceneView)).RemoveValueChanged(sceneview, GeoViewDocumentChanged);
-#endif
-                }
-#endif
-            }
-
-            _geoview = geoview;
-            if (_geoview != null)
-            {
-#if XAMARIN || XAMARIN_FORMS
-                (_geoview as INotifyPropertyChanged).PropertyChanged += GeoView_PropertyChanged;
-#else
-                if (_geoview is MapView mapview)
-                {
-#if NETFX_CORE
-                    _propertyChangedCallbackToken = mapview.RegisterPropertyChangedCallback(MapView.MapProperty, GeoViewDocumentChanged);
-#else
-                    DependencyPropertyDescriptor.FromProperty(MapView.MapProperty, typeof(MapView)).AddValueChanged(mapview, GeoViewDocumentChanged);
-#endif
-                }
-                else if (_geoview is SceneView sceneview)
-                {
-#if NETFX_CORE
-                    _propertyChangedCallbackToken = sceneview.RegisterPropertyChangedCallback(SceneView.SceneProperty, GeoViewDocumentChanged);
-#else
-                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(SceneView)).AddValueChanged(sceneview, GeoViewDocumentChanged);
-#endif
-                }
-#endif
-            }
-
-            OnDocumentChanged();
-        }
-
-#if !XAMARIN && !XAMARIN_FORMS
-        private void GeoViewDocumentChanged(object sender, object e)
-        {
-            OnDocumentChanged();
-        }
-#else
-        private void GeoView_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if ((sender is MapView && e.PropertyName == nameof(MapView.Map)) ||
-                (sender is SceneView && e.PropertyName == nameof(SceneView.Scene)))
-            {
-                OnDocumentChanged();
-            }
-        }
-#endif
-
-        private void SubscribeToDocument(INotifyPropertyChanged loadable)
-        {
-            var listener = new Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs>(loadable)
-            {
-                OnEventAction = (instance, source, eventArgs) => DocumentPropertyChanged(instance, eventArgs.PropertyName),
-                OnDetachAction = (instance, weakEventListener) => instance.PropertyChanged -= weakEventListener.OnEvent
-            };
-            loadable.PropertyChanged += listener.OnEvent;
-        }
-
-        private void DocumentPropertyChanged(object sender, string propertyName)
+        protected override void OnDocumentPropertyChanged(object sender, string propertyName)
         {
             if (propertyName == nameof(Map.Basemap))
             {
                 MarkCollectionDirty(false);
             }
-            else if (propertyName == nameof(Map.OperationalLayers))
+
+            base.OnDocumentPropertyChanged(sender, propertyName);
+        }
+
+        protected override void OnLayerPropertyChanged(ILayerContent layer, string propertyName)
+        {
+            base.OnLayerPropertyChanged(layer, propertyName);
+            if (propertyName == nameof(FeatureLayer.Renderer) && ShowLegend)
             {
                 MarkCollectionDirty(false);
             }
         }
 
-        private void OnDocumentChanged()
+        protected override List<TocItem> OnRebuildCollection()
         {
-            IEnumerable<Layer> layers = null;
-            if (_geoview is MapView mv)
-            {
-                if (mv.Map != null && mv.Map.OperationalLayers == null)
-                {
-                    SubscribeToDocument(mv.Map);
-                }
-                else
-                {
-                    layers = mv.Map?.OperationalLayers;
-                }
-            }
-            else if (_geoview is SceneView sv)
-            {
-                if (sv.Scene != null && sv.Scene.OperationalLayers == null)
-                {
-                    SubscribeToDocument(sv.Scene);
-                }
-                else
-                {
-                    layers = sv.Scene?.OperationalLayers;
-                }
-            }
-
-            if (layers is INotifyCollectionChanged incc)
-            {
-                var listener = new Internal.WeakEventListener<INotifyCollectionChanged, object, NotifyCollectionChangedEventArgs>(incc)
-                {
-                    OnEventAction = (instance, source, eventArgs) => Layers_CollectionChanged(source, eventArgs),
-                    OnDetachAction = (instance, weakEventListener) => instance.CollectionChanged -= weakEventListener.OnEvent
-                };
-                incc.CollectionChanged += listener.OnEvent;
-            }
-
-            TrackLayers(layers);
-
-            MarkCollectionDirty(false);
-        }
-
-        private void Layer_PropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            var layer = sender as Layer;
-            if (e.PropertyName == nameof(Layer.LoadStatus) && layer.LoadStatus == LoadStatus.Loaded)
-            {
-                MarkCollectionDirty();
-            }
-            else if (e.PropertyName == nameof(FeatureLayer.Renderer))
-            {
-                MarkCollectionDirty(false);
-            }
-        }
-
-        private void Layers_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            TrackLayers(sender as IEnumerable<Layer>);
-            MarkCollectionDirty();
-        }
-
-        private IEnumerable<Layer> _currentLayers;
-
-        private void TrackLayers(IEnumerable<Layer> layers)
-        {
-            if (_currentLayers != null)
-            {
-                foreach (var layer in _currentLayers)
-                {
-                    layer.PropertyChanged -= Layer_PropertyChanged;
-                }
-            }
-
-            _currentLayers = layers;
-            if (_currentLayers != null)
-            {
-                foreach (var layer in _currentLayers)
-                {
-                    layer.PropertyChanged += Layer_PropertyChanged;
-                }
-            }
-        }
-
-
-        private bool _isCollectionDirty;
-        private object _dirtyLock = new object();
-
-        private async void MarkCollectionDirty(bool delay = true)
-        {
-            lock (_dirtyLock)
-            {
-                if (_isCollectionDirty)
-                {
-                    return;
-                }
-
-                _isCollectionDirty = true;
-            }
-
-            if (delay)
-            {
-                // Delay update in case of frequent events to reduce load
-                await Task.Delay(250).ConfigureAwait(false);
-            }
-
-            RunOnUIThread(RebuildCollection);
-        }
-
-        private void RebuildCollection()
-        {
-            lock (_dirtyLock)
-            {
-                _isCollectionDirty = false;
-            }
-
-            var newItems = BuildTocList() ?? new List<TocItem>();
-            if (newItems.Count == 0 && _items.Count == 0)
-            {
-                return;
-            }
-
-            if (newItems.Count == 0 || _items.Count == 0)
-            {
-                _items = newItems;
-                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
-                return;
-            }
-
-            int i = 0;
-            for (; i < newItems.Count || i < _items.Count; i++)
-            {
-                var newItem = i < newItems.Count ? newItems[i] : null;
-                var oldItem = i < _items.Count ? _items[i] : null;
-                if (newItem?.Content == oldItem?.Content)
-                {
-                    continue;
-                }
-
-                if (newItem == null)
-                {
-                    // Item was removed from the end
-                    var removedItem = oldItem;
-                    _items.RemoveAt(i);
-                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItem, i));
-                    i--;
-                }
-                else if (!_items.Contains(newItem))
-                {
-                    // Item was added
-                    _items.Insert(i, newItem);
-                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newItem, i));
-                }
-                else
-                {
-                    // Item was removed (or moved)
-                    var removedItem = oldItem;
-                    _items.RemoveAt(i);
-                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItem, i));
-                    i--;
-                }
-            }
-#if DEBUG
-            // Validate the calculated collection is in sync
-            System.Diagnostics.Debug.Assert(newItems.Count == _items.Count, "Legend entry count doesn't match");
-            for (i = 0; i < newItems.Count; i++)
-            {
-                System.Diagnostics.Debug.Assert(newItems[i].Content == _items[i].Content, $"Legend entry {i} doesn't match");
-            }
-#endif
+            return BuildTocList() ?? new List<TocItem>();
         }
 
         private List<TocItem> BuildTocList()
@@ -352,12 +101,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
             IEnumerable<Layer> layers = null;
             Basemap basemap = null;
 
-            if (_geoview is MapView mv)
+            if (GeoView is MapView mv)
             {
                 layers = mv.Map?.OperationalLayers;
                 basemap = mv.Map?.Basemap;
             }
-            else if (_geoview is SceneView sv)
+            else if (GeoView is SceneView sv)
             {
                 layers = sv.Scene?.OperationalLayers;
                 basemap = sv.Scene?.Basemap;
@@ -376,93 +125,6 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
 
             return result;
         }
-
-        private void RunOnUIThread(Action action)
-        {
-#if XAMARIN_FORMS
-            global::Xamarin.Forms.Device.BeginInvokeOnMainThread(action);
-#elif __IOS__
-            _owner.InvokeOnMainThread(action);
-#elif __ANDROID__
-            _owner.PostDelayed(action, 500);
-#elif NETFX_CORE
-            _ = _owner.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => action());
-#else
-            _owner.Dispatcher.Invoke(action);
-#endif
-        }
-
-#region IList<T>
-
-        public int Count => _items.Count;
-
-        public bool IsReadOnly => true;
-
-        public bool IsFixedSize => false;
-
-        public bool IsSynchronized => (_items as ICollection)?.IsSynchronized ?? false;
-
-        public object SyncRoot => (_items as ICollection)?.SyncRoot;
-
-        public TocItem this[int index] { get => _items[index]; set => throw new NotSupportedException(); }
-
-        public void Insert(int index, TocItem item) => throw new NotSupportedException();
-
-        public void RemoveAt(int index) => throw new NotSupportedException();
-
-        public void Add(TocItem item) => throw new NotSupportedException();
-
-        public void Clear() => throw new NotSupportedException();
-
-        public bool Contains(TocItem item) => _items.Contains(item);
-
-        public void CopyTo(TocItem[] array, int arrayIndex) => throw new NotImplementedException();
-
-        public bool Remove(TocItem item) => throw new NotSupportedException();
-
-        public IEnumerator<TocItem> GetEnumerator() => _items.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        public int IndexOf(TocItem item) => _items.IndexOf(item);
-
-#endregion
-
-#region List
-
-        object IList.this[int index] { get => _items[index]; set => throw new NotSupportedException(); }
-
-        int IList.Add(object value) => throw new NotSupportedException();
-
-        void IList.Remove(object value) => throw new NotSupportedException();
-
-        void ICollection.CopyTo(Array array, int index) => ((ICollection)_items).CopyTo(array, index);
-
-        bool IList.Contains(object value) => _items.Contains(value);
-
-        int IList.IndexOf(object value) => ((IList)_items).IndexOf(value);
-
-        void IList.Insert(int index, object value) => throw new NotSupportedException();
-
-#endregion
-
-        private void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
-        {
-            CollectionChanged?.Invoke(this, args);
-            OnPropertyChanged("Item[]");
-            if (args.Action != NotifyCollectionChangedAction.Move)
-            {
-                OnPropertyChanged(nameof(Count));
-            }
-        }
-
-        private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-
-        /// <inheritdoc />
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        /// <inheritdoc />
-        public event NotifyCollectionChangedEventHandler CollectionChanged;
     }
 }
 

--- a/src/Toolkit/Toolkit/Esri.ArcGISRuntime.Toolkit.csproj
+++ b/src/Toolkit/Toolkit/Esri.ArcGISRuntime.Toolkit.csproj
@@ -75,6 +75,7 @@
     <Compile Include="UI\Controls\TimeSlider\TimeExtentChangedEventArgs.cs" />
     <Compile Include="UI\Controls\TimeSlider\TimeSliderLabelMode.cs" />
     <Compile Include="UI\Controls\Legend\LegendEntry.cs" />
+    <Compile Include="UI\ILayerContentItem.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Toolkit/Toolkit/UI/Controls/Legend/LegendEntry.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/Legend/LegendEntry.cs
@@ -24,7 +24,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
     /// <remarks>
     /// The <see cref="Content"/> property will contain the actual object it represents, mainly <see cref="Layer"/>, <see cref="ILayerContent"/> or <see cref="LegendInfo"/>.
     /// </remarks>
-    public class LegendEntry
+    public class LegendEntry : object, ILayerContentItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LegendEntry"/> class.

--- a/src/Toolkit/Toolkit/UI/ILayerContentItem.cs
+++ b/src/Toolkit/Toolkit/UI/ILayerContentItem.cs
@@ -1,0 +1,32 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2018 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using System.ComponentModel;
+
+namespace Esri.ArcGISRuntime.Toolkit.UI
+{
+    /// <summary>
+    /// Internal use only
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface ILayerContentItem
+    {
+        /// <summary>
+        /// Gets the layer content this item encapsulates
+        /// </summary>
+        object Content { get; }
+    }
+}

--- a/src/Toolkit/Toolkit/UI/LayerContentDataSource.cs
+++ b/src/Toolkit/Toolkit/UI/LayerContentDataSource.cs
@@ -1,0 +1,556 @@
+﻿// /*******************************************************************************
+//  * Copyright 2012-2018 Esri
+//  *
+//  *  Licensed under the Apache License, Version 2.0 (the "License");
+//  *  you may not use this file except in compliance with the License.
+//  *  You may obtain a copy of the License at
+//  *
+//  *  http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  *   Unless required by applicable law or agreed to in writing, software
+//  *   distributed under the License is distributed on an "AS IS" BASIS,
+//  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  *   See the License for the specific language governing permissions and
+//  *   limitations under the License.
+//  ******************************************************************************/
+
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.UI;
+#if XAMARIN_FORMS
+using Esri.ArcGISRuntime.Xamarin.Forms;
+using View = Xamarin.Forms.View;
+#else
+using Esri.ArcGISRuntime.UI.Controls;
+#if NETFX_CORE
+using Windows.UI.Core;
+using View = Windows.UI.Xaml.DependencyObject;
+#elif __IOS__
+using View = UIKit.UIView;
+#elif __ANDROID__
+using View = Android.Views.View;
+#else
+using View = System.Windows.DependencyObject;
+#endif
+#endif
+
+#if XAMARIN_FORMS
+namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
+#else
+namespace Esri.ArcGISRuntime.Toolkit.UI
+#endif
+{
+    /// <summary>
+    /// A generic helper class for tracking changes to the layers in a MapView or SceneView and generate a bindable list of information about the map,
+    /// handles changes on multiple threads, yet ensures the collection is only updated on the UI Thread.
+    /// Used by Legend and Table of Contents controls.
+    /// </summary>
+    /// <typeparam name="T">List item type</typeparam>
+    internal abstract class LayerContentDataSource<T> : IList<T>, INotifyCollectionChanged, INotifyPropertyChanged, IList
+        where T : ILayerContentItem
+    {
+        private readonly View _owner;
+        private GeoView _geoview;
+        private List<T> _items = new List<T>();
+
+        protected LayerContentDataSource(View owner)
+        {
+            _owner = owner;
+        }
+
+        protected IList<T> Items => _items;
+
+        protected GeoView GeoView => _geoview;
+
+        private protected void RunOnUIThread(Action action)
+        {
+#if XAMARIN_FORMS
+            global::Xamarin.Forms.Device.BeginInvokeOnMainThread(action);
+#else
+            if (_owner == null)
+            {
+                action();
+                return;
+            }
+#if __IOS__
+            _owner.InvokeOnMainThread(action);
+#elif __ANDROID__
+            _owner.PostDelayed(action, 50);
+#elif NETFX_CORE
+            _ = _owner.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Low, () => action());
+#else
+            _owner.Dispatcher.Invoke(action);
+#endif
+#endif
+        }
+
+#if NETFX_CORE && !XAMARIN_FORMS
+        private long _propertyChangedCallbackToken = 0;
+#endif
+
+        internal void SetGeoView(GeoView geoview)
+        {
+            if (geoview == _geoview)
+            {
+                return;
+            }
+
+            if (_geoview != null)
+            {
+                _geoview.LayerViewStateChanged -= GeoView_LayerViewStateChanged;
+                (_geoview as INotifyPropertyChanged).PropertyChanged += GeoView_PropertyChanged;
+#if XAMARIN || XAMARIN_FORMS
+                (_geoview as INotifyPropertyChanged).PropertyChanged -= GeoView_PropertyChanged;
+#else
+                if (_geoview is MapView mapview)
+                {
+#if NETFX_CORE
+                    mapview.UnregisterPropertyChangedCallback(MapView.MapProperty, _propertyChangedCallbackToken);
+#else
+                    DependencyPropertyDescriptor.FromProperty(MapView.MapProperty, typeof(MapView)).RemoveValueChanged(mapview, GeoViewDocumentChanged);
+#endif
+                }
+                else if (_geoview is SceneView sceneview)
+                {
+#if NETFX_CORE
+                    sceneview.UnregisterPropertyChangedCallback(SceneView.SceneProperty, _propertyChangedCallbackToken);
+#else
+                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(SceneView)).RemoveValueChanged(sceneview, GeoViewDocumentChanged);
+#endif
+                }
+#endif
+            }
+
+            var oldGeoview = _geoview;
+            _geoview = geoview;
+            if (_geoview != null)
+            {
+                _geoview.LayerViewStateChanged += GeoView_LayerViewStateChanged;
+                (_geoview as INotifyPropertyChanged).PropertyChanged += GeoView_PropertyChanged;
+#if XAMARIN || XAMARIN_FORMS
+#else
+                if (_geoview is MapView mapview)
+                {
+#if NETFX_CORE
+                    _propertyChangedCallbackToken = mapview.RegisterPropertyChangedCallback(MapView.MapProperty, GeoViewDocumentChanged);
+#else
+                    DependencyPropertyDescriptor.FromProperty(MapView.MapProperty, typeof(MapView)).AddValueChanged(mapview, GeoViewDocumentChanged);
+#endif
+                }
+                else if (_geoview is SceneView sceneview)
+                {
+#if NETFX_CORE
+                    _propertyChangedCallbackToken = sceneview.RegisterPropertyChangedCallback(SceneView.SceneProperty, GeoViewDocumentChanged);
+#else
+                    DependencyPropertyDescriptor.FromProperty(SceneView.SceneProperty, typeof(SceneView)).AddValueChanged(sceneview, GeoViewDocumentChanged);
+#endif
+                }
+#endif
+            }
+
+            OnGeoViewChanged(oldGeoview, geoview);
+            OnDocumentChanged();
+        }
+
+        protected virtual void OnGeoViewChanged(GeoView oldGeoview, GeoView newGeoview)
+        {
+        }
+
+        private void GeoView_LayerViewStateChanged(object sender, LayerViewStateChangedEventArgs e)
+        {
+            OnLayerViewStateChanged(sender as Layer, e);
+        }
+
+        protected virtual void OnLayerViewStateChanged(Layer layer, LayerViewStateChangedEventArgs layerViewState)
+        {
+        }
+
+#if !XAMARIN && !XAMARIN_FORMS
+        private void GeoViewDocumentChanged(object sender, object e)
+        {
+            OnDocumentChanged();
+            if (_geoview is MapView)
+            {
+                OnGeoViewPropertyChanged(sender as GeoView, nameof(MapView.Map));
+            }
+            else if (_geoview is SceneView)
+            {
+                OnGeoViewPropertyChanged(sender as GeoView, nameof(SceneView.Scene));
+            }
+        }
+#endif
+
+        private void GeoView_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+#if __IOS__ || __ANDROID__ || XAMARIN_FORMS
+            if ((sender is MapView && e.PropertyName == nameof(MapView.Map)) ||
+                (sender is SceneView && e.PropertyName == nameof(SceneView.Scene)))
+            {
+                OnDocumentChanged();
+            }
+#endif
+
+            OnGeoViewPropertyChanged(sender as GeoView, e.PropertyName);
+        }
+
+        protected virtual void OnGeoViewPropertyChanged(GeoView geoView, string propertyName)
+        {
+        }
+
+        private Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs> _documentListener;
+
+        private void SubscribeToDocument(INotifyPropertyChanged document)
+        {
+            if (_documentListener != null)
+            {
+                _documentListener.Detach();
+                _documentListener = null;
+            }
+
+            if (document != null)
+            {
+                _documentListener = new Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs>(document)
+                {
+                    OnEventAction = (instance, source, eventArgs) => DocumentPropertyChanged(instance, eventArgs.PropertyName),
+                    OnDetachAction = (instance, weakEventListener) => instance.PropertyChanged -= weakEventListener.OnEvent
+                };
+                document.PropertyChanged += _documentListener.OnEvent;
+            }
+        }
+
+        private void DocumentPropertyChanged(object sender, string propertyName)
+        {
+            if (propertyName == nameof(Map.OperationalLayers))
+            {
+                TrackOperationalLayers();
+                MarkCollectionDirty(false);
+            }
+            else if (propertyName == nameof(Map.Basemap))
+            {
+                SubscribeToBasemap((sender as Map)?.Basemap ?? (sender as Scene)?.Basemap);
+            }
+
+            OnDocumentPropertyChanged(sender, propertyName);
+        }
+
+        protected virtual void OnDocumentPropertyChanged(object sender, string propertyName)
+        {
+        }
+
+        private Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs> _basemapListener;
+
+        private void SubscribeToBasemap(Basemap basemap)
+        {
+            if (_basemapListener != null)
+            {
+                _basemapListener.Detach();
+                _basemapListener = null;
+            }
+
+            if (basemap != null)
+            {
+                _basemapListener = new Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs>(basemap)
+                {
+                    OnEventAction = (instance, source, eventArgs) => BasemapPropertyChanged(instance, eventArgs.PropertyName),
+                    OnDetachAction = (instance, weakEventListener) => instance.PropertyChanged -= weakEventListener.OnEvent
+                };
+                basemap.PropertyChanged += _basemapListener.OnEvent;
+            }
+        }
+
+        private void BasemapPropertyChanged(INotifyPropertyChanged instance, string propertyName)
+        {
+            OnBasemapPropertyChanged(instance as Basemap, propertyName);
+        }
+
+        protected void OnBasemapPropertyChanged(Basemap basemap, string propertyName)
+        {
+        }
+
+        private void OnDocumentChanged()
+        {
+            SubscribeToDocument(null); // Detaches listeners
+            if (_geoview is MapView mv)
+            {
+                if (mv.Map != null)
+                {
+                    SubscribeToDocument(mv.Map);
+                }
+            }
+            else if (_geoview is SceneView sv)
+            {
+                if (sv.Scene != null)
+                {
+                    SubscribeToDocument(sv.Scene);
+                }
+            }
+
+            TrackOperationalLayers();
+
+            OnDocumentReset();
+            MarkCollectionDirty(false);
+        }
+
+        protected virtual void OnDocumentReset()
+        {
+        }
+
+        private void Layer_PropertyChanged(ILayerContent sender, string propertyName)
+        {
+            var layer = sender as ILayerContent;
+            if (layer is ILoadable loadable && propertyName == nameof(ILoadable.LoadStatus) && loadable.LoadStatus == LoadStatus.Loaded)
+            {
+                MarkCollectionDirty();
+            }
+            else if (propertyName == nameof(ILayerContent.SublayerContents))
+            {
+                TrackOperationalLayers();
+                MarkCollectionDirty();
+            }
+
+            OnLayerPropertyChanged(layer, propertyName);
+        }
+
+        protected virtual void OnLayerPropertyChanged(ILayerContent layer, string propertyName)
+        {
+        }
+
+        private List<Action> _operationalLayerTrackingDetachActions;
+
+        private void TrackOperationalLayers()
+        {
+            // Detach all listeners, and create a new recursive set
+            if (_operationalLayerTrackingDetachActions != null)
+            {
+                foreach (var action in _operationalLayerTrackingDetachActions)
+                {
+                    action();
+                }
+
+                _operationalLayerTrackingDetachActions = null;
+            }
+
+            IEnumerable<Layer> layers = null;
+
+            if (_geoview is MapView mv)
+            {
+                layers = mv.Map?.OperationalLayers;
+            }
+            else if (_geoview is SceneView sv)
+            {
+                layers = sv.Scene?.OperationalLayers;
+            }
+
+            _operationalLayerTrackingDetachActions = new List<Action>(TrackLayerContentsRecursive(layers));
+        }
+
+        private IEnumerable<Action> TrackLayerContentsRecursive(IEnumerable<ILayerContent> layers)
+        {
+            if (layers != null)
+            {
+                foreach (var layer in layers)
+                {
+                    if (layer is INotifyPropertyChanged inpc)
+                    {
+                        var listener = new Internal.WeakEventListener<INotifyPropertyChanged, object, PropertyChangedEventArgs>(inpc)
+                        {
+                            OnEventAction = (instance, source, eventArgs) => Layer_PropertyChanged(instance as ILayerContent, eventArgs.PropertyName),
+                            OnDetachAction = (instance, weakEventListener) => instance.PropertyChanged -= weakEventListener.OnEvent
+                        };
+                        inpc.PropertyChanged += listener.OnEvent;
+                        yield return listener.Detach;
+                    }
+
+                    foreach (var sublayerAction in TrackLayerContentsRecursive(layer.SublayerContents))
+                    {
+                        yield return sublayerAction;
+                    }
+                }
+
+                if (layers is INotifyCollectionChanged incc)
+                {
+                    var listener = new Internal.WeakEventListener<INotifyCollectionChanged, object, NotifyCollectionChangedEventArgs>(incc)
+                    {
+                        OnEventAction = (instance, source, eventArgs) => Layers_CollectionChanged(source, eventArgs),
+                        OnDetachAction = (instance, weakEventListener) => instance.CollectionChanged -= weakEventListener.OnEvent
+                    };
+                    incc.CollectionChanged += listener.OnEvent;
+                    yield return listener.Detach;
+                }
+            }
+        }
+
+        private void Layers_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            TrackOperationalLayers();
+            MarkCollectionDirty();
+        }
+
+        private bool _isCollectionDirty;
+        private object _dirtyLock = new object();
+
+        protected async void MarkCollectionDirty(bool delay = true)
+        {
+            lock (_dirtyLock)
+            {
+                if (_isCollectionDirty)
+                {
+                    return;
+                }
+
+                _isCollectionDirty = true;
+            }
+
+            if (delay)
+            {
+                // Delay update in case of frequent events to reduce load
+                await Task.Delay(250).ConfigureAwait(false);
+            }
+
+            RunOnUIThread(RebuildCollection);
+        }
+
+        private void RebuildCollection()
+        {
+            lock (_dirtyLock)
+            {
+                _isCollectionDirty = false;
+            }
+
+            var newItems = OnRebuildCollection();
+            if (newItems.Count == 0 && _items.Count == 0)
+            {
+                return;
+            }
+
+            if (newItems.Count == 0 || _items.Count == 0)
+            {
+                _items = newItems;
+                OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+                return;
+            }
+
+            int i = 0;
+            for (; i < newItems.Count || i < _items.Count; i++)
+            {
+                var newItem = i < newItems.Count ? newItems[i] : default(T);
+                var oldItem = i < _items.Count ? _items[i] : default(T);
+                if (newItem?.Content == oldItem?.Content)
+                {
+                    continue;
+                }
+
+                if (newItem == null)
+                {
+                    // Item was removed from the end
+                    var removedItem = oldItem;
+                    _items.RemoveAt(i);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItem, i));
+                    i--;
+                }
+                else if (!_items.Contains(newItem))
+                {
+                    // Item was added
+                    _items.Insert(i, newItem);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newItem, i));
+                }
+                else
+                {
+                    // Item was removed (or moved)
+                    var removedItem = oldItem;
+                    _items.RemoveAt(i);
+                    OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, oldItem, i));
+                    i--;
+                }
+            }
+#if DEBUG
+            // Validate the calculated collection is in sync
+            System.Diagnostics.Debug.Assert(newItems.Count == _items.Count, "Entry count doesn't match");
+            for (i = 0; i < newItems.Count; i++)
+            {
+                System.Diagnostics.Debug.Assert(newItems[i].Content == _items[i].Content, $"Entry {i} doesn't match");
+            }
+#endif
+        }
+
+        protected abstract List<T> OnRebuildCollection();
+
+        #region IList<T>
+
+        public int Count => Items.Count;
+
+        public bool IsReadOnly => true;
+
+        public bool IsFixedSize => false;
+
+        public bool IsSynchronized => (Items as ICollection)?.IsSynchronized ?? false;
+
+        public object SyncRoot => (Items as ICollection)?.SyncRoot;
+
+        public T this[int index] { get => Items[index]; set => throw new NotSupportedException(); }
+
+        public void Insert(int index, T item) => throw new NotSupportedException();
+
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public void Add(T item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(T item) => Items.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => Items.CopyTo(array, arrayIndex);
+
+        public bool Remove(T item) => throw new NotSupportedException();
+
+        public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
+
+        public int IndexOf(T item) => Items.IndexOf(item);
+
+        #endregion
+
+        #region List
+
+        object IList.this[int index] { get => Items[index]; set => throw new NotSupportedException(); }
+
+        int IList.Add(object value) => throw new NotSupportedException();
+
+        void IList.Remove(object value) => throw new NotSupportedException();
+
+        void ICollection.CopyTo(Array array, int index) => ((ICollection)Items).CopyTo(array, index);
+
+        bool IList.Contains(object value) => ((IList)Items).Contains(value);
+
+        int IList.IndexOf(object value) => ((IList)Items).IndexOf(value);
+
+        void IList.Insert(int index, object value) => throw new NotSupportedException();
+
+        #endregion
+
+        private protected void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
+        {
+            CollectionChanged?.Invoke(this, args);
+            OnPropertyChanged("Item[]");
+            if (args.Action != NotifyCollectionChangedAction.Move)
+            {
+                OnPropertyChanged(nameof(Count));
+            }
+        }
+
+        private protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
+    }
+}


### PR DESCRIPTION
Lots of the same code for tracking layer changes was duplicated in Legend and ToC. Moved common code to base class, so any fixes to layer tracking are fixed in both cases.
Subclasses now mainly focus on building the data model needed for the controls, and base class will handle efficient collection change events.

This PR addresses several issues with tracking changes to layer collections and properties.

Fixes issues 2+3 reported in #308 (Issue 1 is expected as no basemap name was provided). Some of these issues also applied to Legend.

FYI @GeoITwinkle