### PR TITLE
Update default legend templates for UWP & WPF

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/Legend/LegendSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/Legend/LegendSample.xaml
@@ -16,6 +16,7 @@
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <esriToolkit:Legend Grid.Row="0"
                                 x:Name="legend"
@@ -23,9 +24,12 @@
             <CheckBox Content="Filter By Visible Scale Range"
                       IsChecked="{x:Bind legend.FilterByVisibleScaleRange, Mode=TwoWay}"	
                       Grid.Row="1" />
+            <CheckBox Content="Filter Hidden Layers"
+                      IsChecked="{x:Bind legend.FilterHiddenLayers, Mode=TwoWay}"	
+                      Grid.Row="2" />
             <CheckBox Content="Reverse Layer Order"
                       IsChecked="{x:Bind legend.ReverseLayerOrder, Mode=TwoWay}"
-                      Grid.Row="2" />
+                      Grid.Row="3" />
         </Grid>
         <esri:MapView Map="{x:Bind Map}"
                       x:Name="mapView"

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/Legend/LegendSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/Legend/LegendSample.xaml.cs
@@ -22,12 +22,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.Legend
 
         private static Map CreateMap()
         {
-            Map map = new Map(Basemap.CreateLightGrayCanvasVector())
-            {
-                InitialViewpoint = new Viewpoint(new Envelope(-178, 17.8, -65, 71.4, SpatialReference.Create(4269)))
-            };
-            map.OperationalLayers.Add(new ArcGISMapImageLayer(new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")));
-            map.OperationalLayers.Add(new FeatureLayer(new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")));
+            Map map = new Map(new Uri("http://www.arcgis.com/home/webmap/viewer.html?webmap=f1ed0d220d6447a586203675ed5ac213"));
             return map;
         }
     }

--- a/src/Toolkit/Toolkit.UWP/UI/Controls/Legend/Legend.Theme.xaml
+++ b/src/Toolkit/Toolkit.UWP/UI/Controls/Legend/Legend.Theme.xaml
@@ -15,14 +15,14 @@
              <Setter Property="LayerItemTemplate">
             <Setter.Value>
               <DataTemplate>
-                <TextBlock Text="{Binding Content.Name}" FontSize="18" />
+                <TextBlock Text="{Binding Content.Name}" FontSize="16" TextWrapping="Wrap" FontWeight="Semibold" />
               </DataTemplate>
             </Setter.Value>
         </Setter>
         <Setter Property="SublayerItemTemplate">
           <Setter.Value>
             <DataTemplate>
-              <TextBlock Text="{Binding Content.Name}" FontSize="14" />
+              <TextBlock Text="{Binding Content.Name}" FontSize="14" TextWrapping="Wrap" />
             </DataTemplate>
           </Setter.Value>
         </Setter>
@@ -31,7 +31,7 @@
             <DataTemplate>
               <StackPanel Orientation="Horizontal">
                 <controls:SymbolDisplay Symbol="{Binding Content.Symbol}" MaxHeight="40" Width="40" Margin="0,0,5,0" VerticalAlignment="Center" />
-                <TextBlock Text="{Binding Content.Name}" FontSize="12" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Content.Name}" FontSize="12" VerticalAlignment="Center" TextWrapping="Wrap" />
               </StackPanel>
             </DataTemplate>
           </Setter.Value>
@@ -49,6 +49,12 @@
                                           BorderThickness="0"
                                           Padding="0" SelectionMode="None" 
                                           IsItemClickEnabled="False" >
+                        <ListView.Resources>
+                          <SolidColorBrush x:Key="SystemControlTransparentRevealBackgroundBrush" Color="Transparent" />
+                          <SolidColorBrush x:Key="SystemControlTransparentRevealBorderBrush" Color="Transparent" />
+                          <Thickness x:Key="ListViewItemRevealBorderThemeThickness">0</Thickness>
+                          <SolidColorBrush x:Key="ListViewItemRevealPlaceholderBackground" Color="Transparent" />
+                        </ListView.Resources>
                       </ListView>
                     </Border>
                 </ControlTemplate>

--- a/src/Toolkit/Toolkit.UWP/UI/Controls/Legend/Legend.Theme.xaml
+++ b/src/Toolkit/Toolkit.UWP/UI/Controls/Legend/Legend.Theme.xaml
@@ -15,7 +15,7 @@
              <Setter Property="LayerItemTemplate">
             <Setter.Value>
               <DataTemplate>
-                <TextBlock Text="{Binding Content.Name}" FontSize="16" TextWrapping="Wrap" FontWeight="Semibold" />
+                <TextBlock Text="{Binding Content.Name}" FontSize="14" TextWrapping="Wrap" FontWeight="Semibold" />
               </DataTemplate>
             </Setter.Value>
         </Setter>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/Legend/Legend.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/Legend/Legend.Theme.xaml
@@ -9,14 +9,18 @@
     <Setter Property="LayerItemTemplate">
       <Setter.Value>
         <DataTemplate>
-          <TextBlock Text="{Binding Content.Name}" FontSize="18" />
+          <TextBlock Text="{Binding Content.Name}" 
+                     FontSize="14" 
+                     TextWrapping="Wrap" 
+                     FontWeight="Semibold"
+                     Margin="0,0,0,5" />
         </DataTemplate>
       </Setter.Value>
     </Setter>
     <Setter Property="SublayerItemTemplate">
       <Setter.Value>
         <DataTemplate>
-          <TextBlock Text="{Binding Content.Name}" FontSize="14" />
+          <TextBlock Text="{Binding Content.Name}" FontSize="14" TextWrapping="Wrap" />
         </DataTemplate>
       </Setter.Value>
     </Setter>
@@ -25,7 +29,10 @@
         <DataTemplate>
           <StackPanel Orientation="Horizontal">
             <controls:SymbolDisplay Symbol="{Binding Content.Symbol}" MaxHeight="40" Width="40" Margin="0,0,5,0" />
-            <TextBlock Text="{Binding Content.Name}" FontSize="12" />
+            <TextBlock Text="{Binding Content.Name}" 
+                       FontSize="12" 
+                       TextWrapping="Wrap"
+                       VerticalAlignment="Center" />
           </StackPanel>
         </DataTemplate>
       </Setter.Value>
@@ -33,15 +40,17 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="controls:Legend">
-            <ListView x:Name="List"
+          <ScrollViewer>
+            <ItemsControl x:Name="List"
                   Foreground="{TemplateBinding Foreground}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   Background="{TemplateBinding Background}"
                   ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
                   Margin="{TemplateBinding Padding}"
-                  Padding="0">
-            </ListView>
+                  Padding="5">
+            </ItemsControl>
+          </ScrollViewer>
         </ControlTemplate>
       </Setter.Value>
     </Setter>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/Legend/Legend.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/Legend/Legend.Theme.xaml
@@ -40,17 +40,28 @@
     <Setter Property="Template">
       <Setter.Value>
         <ControlTemplate TargetType="controls:Legend">
-          <ScrollViewer>
-            <ItemsControl x:Name="List"
-                  Foreground="{TemplateBinding Foreground}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  Background="{TemplateBinding Background}"
-                  ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
-                  Margin="{TemplateBinding Padding}"
-                  Padding="5">
-            </ItemsControl>
-          </ScrollViewer>
+          <ListView x:Name="List"
+                Foreground="{TemplateBinding Foreground}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Background="{TemplateBinding Background}"
+                ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                Margin="{TemplateBinding Padding}"
+                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                Padding="5">
+            <ListView.ItemContainerStyle>
+              <Style TargetType="{x:Type ListViewItem}">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Template">
+                  <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ListViewItem}">
+                      <ContentPresenter />
+                    </ControlTemplate>
+                  </Setter.Value>
+                </Setter>
+              </Style>
+            </ListView.ItemContainerStyle>
+          </ListView>
         </ControlTemplate>
       </Setter.Value>
     </Setter>


### PR DESCRIPTION
Summary of changes:

* Changes font styling slightly to more closely match default behavior from other apps, including the new Online map viewer
    * Layer names slightly smaller
    * Bolded layer names
* Wrap text instead of horizontally scrolling - more closely matches other UIs and works better out of the box (imho - this is debatable)
* Removes the (imho) distracting hover/reveal effect in the UWP listview; the legend isn't interactive, so it shouldn't have the reveal effect (per my interpretation of [the guidelines](https://docs.microsoft.com/en-us/windows/uwp/design/style/reveal#dos-and-donts))
* Removes the hover effect in WPF - legend isn't interactive so there shouldn't be hover effects
* Updates the UWP sample to show a more complex map (needed for testing wrapping behavior and scrolling)