### PR TITLE
ScaleLine: Convert value to DIPs for Android

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/ScaleLine/ScaleLine.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/ScaleLine/ScaleLine.cs
@@ -267,6 +267,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             {
                 return double.NaN;
             }
+#if __ANDROID__
+            // Need to convert the value to DIPs
+            unitsPerPixel /= Android.Util.TypedValue.ApplyDimension(Android.Util.ComplexUnitType.Dip, 1, Internal.ViewExtensions.GetDisplayMetrics());
+#endif
 
             var center = visibleArea.Extent.GetCenter();
             var centerOnePixelOver = new Geometry.MapPoint(center.X + unitsPerPixel, center.Y, center.SpatialReference);


### PR DESCRIPTION
Android reports this value in raw pixels, but scale calculation is based on DIPs.
This addresses #319 for the native Android ScaleLine control.
It does however not address it for Xamarin.Forms because that bug is in the Runtime SDK, and 100.8 will ship with a fix for that bit.