### PR TITLE
Weak event listener crash repro and fix

### DIFF
--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/Legend/LegendSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/Legend/LegendSample.xaml
@@ -31,6 +31,8 @@
                           Content="Filter non-visible layers" />
                 <CheckBox IsChecked="{Binding ReverseLayerOrder, ElementName=legend, Mode=TwoWay}"
                           Content="Reverse Layer Order" />
+                <Button Content="Switch to original map" Click="SwitchToOriginalMap_Click" />
+                <Button Content="Switch to alternate map" Click="SwitchToAlternateMap_Click" />
             </StackPanel>
             
         </Grid>

--- a/src/Samples/Toolkit.SampleApp.WPF/Samples/Legend/LegendSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF/Samples/Legend/LegendSample.xaml.cs
@@ -1,12 +1,25 @@
-﻿using System.Windows.Controls;
+﻿using System;
+using System.Windows.Controls;
 
 namespace Esri.ArcGISRuntime.Toolkit.Samples.Legend
 {
     public partial class LegendSample : UserControl
     {
+        private const string defaultMapUrl = "http://www.arcgis.com/home/webmap/viewer.html?webmap=f1ed0d220d6447a586203675ed5ac213";
+        private const string alternateMapUrl = "https://arcgisruntime.maps.arcgis.com/home/item.html?id=16f1b8ba37b44dc3884afc8d5f454dd2";
         public LegendSample()
         {
             InitializeComponent();
+        }
+
+        private void SwitchToOriginalMap_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            mapView.Map = new Mapping.Map(new Uri(defaultMapUrl));
+        }
+
+        private void SwitchToAlternateMap_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            mapView.Map = new Mapping.Map(new Uri(alternateMapUrl));
         }
     }
 }

--- a/src/Toolkit/Toolkit/WeakEventListener.cs
+++ b/src/Toolkit/Toolkit/WeakEventListener.cs
@@ -90,12 +90,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
         /// </summary>
         public void Detach()
         {
-            TInstance target = (TInstance)_weakInstance.Target;
-            if (OnDetachAction != null)
+            if (_weakInstance?.Target is TInstance target)
             {
-                OnDetachAction(target, this);
-                OnDetachAction = null;
+                OnDetachAction?.Invoke(target, this);
             }
+
+            OnDetachAction = null;
         }
     }
 


### PR DESCRIPTION
I noticed that the `WeakReference.Target` was null when `Detach` as called, which I think might be valid behavior. Target was null checked elsewhere but not in `Detach`.

I updated the legend sample with a repro case that showed the issue, and now doesn't show the issue with the fix applied.