### PR TITLE
Make it simpler to switch toolkit samples over to use nuget references instead

### DIFF
--- a/src/ARSamples/ARToolkit.SampleApp.Android/ARToolkit.SampleApp.Android.csproj
+++ b/src/ARSamples/ARToolkit.SampleApp.Android/ARToolkit.SampleApp.Android.csproj
@@ -141,11 +141,14 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj">
       <Project>{168467dc-6d2d-477a-9ac2-f1486fa67e0a}</Project>
       <Name>Esri.ArcGISRuntime.ARToolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\fullscalear.axml">

--- a/src/ARSamples/ARToolkit.SampleApp.UWP/ARToolkit.SampleApp.UWP.csproj
+++ b/src/ARSamples/ARToolkit.SampleApp.UWP/ARToolkit.SampleApp.UWP.csproj
@@ -168,11 +168,14 @@
       <Version>3.1.1</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj">
       <Project>{190a1f64-46a7-44b5-806f-d9633fa94783}</Project>
       <Name>Esri.ArcGISRuntime.ARToolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
   <Import Project="..\SampleHelpers\SampleHelpers.projitems" Label="Shared" />
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/src/ARSamples/ARToolkit.SampleApp.iOS/ARToolkit.SampleApp.iOS.csproj
+++ b/src/ARSamples/ARToolkit.SampleApp.iOS/ARToolkit.SampleApp.iOS.csproj
@@ -175,11 +175,14 @@
       <Visible>false</Visible>
     </ImageAsset>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj">
       <Project>{190a1f64-46a7-44b5-806f-d9633fa94783}</Project>
       <Name>Esri.ArcGISRuntime.ARToolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
   <Import Project="..\SampleHelpers\SampleHelpers.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/ARSamples/ARToolkit.Samples.Forms.Android/ARToolkit.Samples.Forms.Android.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Forms.Android/ARToolkit.Samples.Forms.Android.csproj
@@ -105,18 +105,19 @@
     <Folder Include="Resources\drawable\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj">
-      <Project>{43c278cb-f076-4519-b916-c267c15927a6}</Project>
-      <Name>Esri.ArcGISRuntime.ARToolkit.Forms</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj">
-      <Project>{190a1f64-46a7-44b5-806f-d9633fa94783}</Project>
-      <Name>Esri.ArcGISRuntime.ARToolkit</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\ARToolkit.Samples.Forms\ARToolkit.Samples.Forms.csproj">
+      <ProjectReference Include="..\ARToolkit.Samples.Forms\ARToolkit.Samples.Forms.csproj">
       <Project>{3b4245f2-c20b-4dfb-87b5-1aec123be464}</Project>
       <Name>ARToolkit.Samples.Forms</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
+    <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj" />
+    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(ArcGISRuntimePackageVersion)"/>
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
+  </ItemGroup>
+
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/src/ARSamples/ARToolkit.Samples.Forms.UWP/ARToolkit.Samples.Forms.UWP.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Forms.UWP/ARToolkit.Samples.Forms.UWP.csproj
@@ -149,18 +149,19 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj">
-      <Project>{9cb71063-b6a7-4bca-b740-6eb9d3b4ece9}</Project>
-      <Name>Esri.ArcGISRuntime.ARToolkit.Forms</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj">
-      <Project>{168467dc-6d2d-477a-9ac2-f1486fa67e0a}</Project>
-      <Name>Esri.ArcGISRuntime.ARToolkit</Name>
-    </ProjectReference>
     <ProjectReference Include="..\ARToolkit.Samples.Forms\ARToolkit.Samples.Forms.csproj">
       <Project>{3b4245f2-c20b-4dfb-87b5-1aec123be464}</Project>
       <Name>ARToolkit.Samples.Forms</Name>
     </ProjectReference>
+  </ItemGroup> 
+    
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
+    <ProjectReference Include="..\..\ARToolkit\Esri.ArcGISRuntime.ARToolkit.csproj" />
+    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(ArcGISRuntimePackageVersion)"/>
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/src/ARSamples/ARToolkit.Samples.Forms.iOS/ARToolkit.Samples.Forms.iOS.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Forms.iOS/ARToolkit.Samples.Forms.iOS.csproj
@@ -165,13 +165,15 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj">
-      <Project>{9cb71063-b6a7-4bca-b740-6eb9d3b4ece9}</Project>
-      <Name>Esri.ArcGISRuntime.ARToolkit.Forms</Name>
-    </ProjectReference>
     <ProjectReference Include="..\ARToolkit.Samples.Forms\ARToolkit.Samples.Forms.csproj">
       <Project>{3b4245f2-c20b-4dfb-87b5-1aec123be464}</Project>
       <Name>ARToolkit.Samples.Forms</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
+    <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit.Forms" Version="$(ArcGISRuntimePackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/ARSamples/ARToolkit.Samples.Forms/ARToolkit.Samples.Forms.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Forms/ARToolkit.Samples.Forms.csproj
@@ -13,7 +13,13 @@
       <Version>$(XamarinFormsPackageVersion)</Version>
     </PackageReference>
     <PackageReference Include="Xam.Plugins.Settings" Version="3.1.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.ARToolkit.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,6 +43,9 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)..\Output\NuGet\$(Configuration)\</PackageOutputPath>
 
     <NoWarn>$(NoWarn);NU5105</NoWarn>
+	
+	<!-- Set to true to make sample apps use Toolkit nuget packages instead -->
+	<UseNugetReferences>false</UseNugetReferences>
   </PropertyGroup>
 
   <Choose>

--- a/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
+++ b/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
@@ -89,11 +89,14 @@
     <Folder Include="Resources\mipmap-xxhdpi\" />
     <Folder Include="Resources\mipmap-xxxhdpi\" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Android">

--- a/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
+++ b/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
@@ -244,11 +244,14 @@
       <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.UWP">

--- a/src/Samples/Toolkit.SampleApp.WPF/Toolkit.Samples.WPF.csproj
+++ b/src/Samples/Toolkit.SampleApp.WPF/Toolkit.Samples.WPF.csproj
@@ -196,7 +196,7 @@
       <Version>$(ArcGISRuntimePackageVersion)</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\Toolkit.Preview\Toolkit.Preview\Esri.ArcGISRuntime.Toolkit.Preview.csproj">
       <Project>{c0f42fba-15f8-4d1e-b60f-06bb32ca19da}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit.Preview</Name>
@@ -205,6 +205,10 @@
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)" />
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Preview" Version="$(ArcGISRuntimePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Samples\PopupViewer\info.png" />

--- a/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
+++ b/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
@@ -88,11 +88,14 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.iOS">

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.Android/Toolkit.Samples.Forms.Android.csproj
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.Android/Toolkit.Samples.Forms.Android.csproj
@@ -92,7 +92,7 @@
     <Folder Include="Resources\drawable-xxxhdpi\" />
     <Folder Include="Resources\drawable\" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
@@ -100,7 +100,13 @@
     <ProjectReference Include="..\..\..\Toolkit.Forms\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj">
       <Project>{bc141500-2741-4f13-86dc-2fa002422c60}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</Name>
-    </ProjectReference>
+    </ProjectReference>  
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)"/>
+	<PackageReference Include="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Toolkit.Samples.Forms\Toolkit.Samples.Forms.csproj">
       <Project>{d7b89b7d-f360-4a68-aecb-c27caddc8118}</Project>
       <Name>Toolkit.Samples.Forms</Name>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.UWP/Toolkit.Samples.Forms.UWP.csproj
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.UWP/Toolkit.Samples.Forms.UWP.csproj
@@ -175,7 +175,7 @@
     <PackageReference Include="Xamarin.Forms" Version="$(XamarinFormsPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
@@ -183,11 +183,17 @@
     <ProjectReference Include="..\..\..\Toolkit.Forms\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj">
       <Project>{bc141500-2741-4f13-86dc-2fa002422c60}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</Name>
-    </ProjectReference>
+    </ProjectReference>  
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Toolkit.Samples.Forms\Toolkit.Samples.Forms.csproj">
       <Project>{d7b89b7d-f360-4a68-aecb-c27caddc8118}</Project>
       <Name>Toolkit.Samples.Forms</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)"/>
+	<PackageReference Include="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '15.0' ">
     <VisualStudioVersion>15.0</VisualStudioVersion>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.iOS/Toolkit.Samples.Forms.iOS.csproj
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms.iOS/Toolkit.Samples.Forms.iOS.csproj
@@ -150,7 +150,7 @@
     <PackageReference Include="Xamarin.Forms" Version="$(XamarinFormsPackageVersion)" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\..\Toolkit\Toolkit\Esri.ArcGISRuntime.Toolkit.csproj">
       <Project>{332171e3-4d72-4148-9ddf-341cafb61ca3}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit</Name>
@@ -158,7 +158,13 @@
     <ProjectReference Include="..\..\..\Toolkit.Forms\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj">
       <Project>{bc141500-2741-4f13-86dc-2fa002422c60}</Project>
       <Name>Esri.ArcGISRuntime.Toolkit.Xamarin.Forms</Name>
-    </ProjectReference>
+    </ProjectReference>  
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit" Version="$(ArcGISRuntimePackageVersion)"/>
+	<PackageReference Include="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Toolkit.Samples.Forms\Toolkit.Samples.Forms.csproj">
       <Project>{d7b89b7d-f360-4a68-aecb-c27caddc8118}</Project>
       <Name>Toolkit.Samples.Forms</Name>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Toolkit.Samples.Forms.csproj
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Toolkit.Samples.Forms.csproj
@@ -9,8 +9,11 @@
     <PackageReference Include="Xamarin.Forms" Version="$(XamarinFormsPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'!='true'">
     <ProjectReference Include="..\..\..\Toolkit.Forms\Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseNugetReferences)'=='true'">
+    <PackageReference Include="Esri.ArcGISRuntime.Toolkit.Xamarin.Forms" Version="$(ArcGISRuntimePackageVersion)"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Simplifies testing the generated nuget packages by setting `UseNugetReferences=true`