### PR TITLE
Improves the appearance of the popupviewer for iOS

### DIFF
--- a/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/DetailsItemCell.cs
+++ b/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/DetailsItemCell.cs
@@ -36,7 +36,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             _label = new UILabel()
             {
-                Font = UIFont.SystemFontOfSize(UIFont.SystemFontSize),
+                Font = UIFont.PreferredBody,
                 TextColor = UIColor.Gray,
                 BackgroundColor = UIColor.Clear,
                 ContentMode = UIViewContentMode.TopLeft,
@@ -48,7 +48,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             _formattedValue = new UILabel()
             {
-                Font = UIFont.SystemFontOfSize(UIFont.SystemFontSize),
+                Font = UIFont.PreferredCaption1,
                 TextColor = UIColor.Black,
                 BackgroundColor = UIColor.Clear,
                 ContentMode = UIViewContentMode.TopLeft,
@@ -81,8 +81,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         public override void UpdateConstraints()
         {
             base.UpdateConstraints();
-            _label.SetContentCompressionResistancePriority((float)UILayoutPriority.DefaultHigh, UILayoutConstraintAxis.Vertical);
-            _formattedValue.SetContentCompressionResistancePriority((float)UILayoutPriority.DefaultHigh, UILayoutConstraintAxis.Vertical);
 
             _label.SetContentHuggingPriority((float)UILayoutPriority.DefaultHigh, UILayoutConstraintAxis.Horizontal);
             _formattedValue.SetContentHuggingPriority((float)UILayoutPriority.DefaultHigh, UILayoutConstraintAxis.Horizontal);
@@ -94,11 +92,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             _constraintsUpdated = true;
             var margin = ContentView.LayoutMarginsGuide;
 
-            _label.TopAnchor.ConstraintEqualTo(margin.TopAnchor).Active = true;
-            _label.LeftAnchor.ConstraintEqualTo(margin.LeftAnchor).Active = true;
+            NSLayoutConstraint.ActivateConstraints(new[]
+            {
+                _label.LeadingAnchor.ConstraintEqualTo(margin.LeadingAnchor),
+                _label.TopAnchor.ConstraintEqualTo(margin.TopAnchor),
+                _label.TrailingAnchor.ConstraintEqualTo(margin.TrailingAnchor),
 
-            _formattedValue.TopAnchor.ConstraintEqualTo(_label.BottomAnchor).Active = true;
-            _formattedValue.LeftAnchor.ConstraintEqualTo(margin.LeftAnchor).Active = true;
+                _formattedValue.TopAnchor.ConstraintEqualTo(_label.BottomAnchor),
+                _formattedValue.LeadingAnchor.ConstraintEqualTo(margin.LeadingAnchor),
+                _formattedValue.TrailingAnchor.ConstraintEqualTo(margin.TrailingAnchor),
+
+                ContentView.BottomAnchor.ConstraintEqualTo(_formattedValue.BottomAnchor)
+            });
         }
     }
 }

--- a/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/PopupViewer.iOS.cs
+++ b/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/PopupViewer.iOS.cs
@@ -103,9 +103,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 AllowsSelection = false,
                 Bounces = true,
                 TranslatesAutoresizingMaskIntoConstraints = false,
-                AutoresizingMask = UIViewAutoresizing.All,
                 RowHeight = UITableView.AutomaticDimension,
-                EstimatedRowHeight = (nfloat)(UIFont.LabelFontSize * 2.4),
             };
             _detailsList.RegisterClassForCellReuse(typeof(DetailsItemCell), PopupViewerTableSource.CellId);
             AddSubviews(_editSummary, _customHtmlDescription, _detailsList);

--- a/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/PopupViewerTableSource.cs
+++ b/src/Toolkit/Toolkit.iOS/UI/Controls/PopupViewer/PopupViewerTableSource.cs
@@ -51,7 +51,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
         public override nfloat GetHeightForRow(UITableView tableView, NSIndexPath indexPath)
         {
-            return (nfloat)(UIFont.LabelFontSize * 2.4);
+            return UITableView.AutomaticDimension;
         }
 
         public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)


### PR DESCRIPTION
Previously, the popup viewer didn't work well with dynamic type. Now it adapts to any system font settings, including larger accessibility sizes.

| Smallest text | Largest text |
|-----------|-----------|
| ![updated_smalltext](https://user-images.githubusercontent.com/29742178/91791775-d7849b80-ebc8-11ea-9563-32b11a5eccc9.PNG) | ![updated_largetext](https://user-images.githubusercontent.com/29742178/91791785-dd7a7c80-ebc8-11ea-8a22-61e2cfcab728.PNG) |

The new appearance is a little different than the old appearance on the smallest text size, but I think that is ok because there was some clipping of descenders previously (e.g. y, g)