### PR TITLE
Update ARToolkit to use same MSBuild.Sdk.Extras and TargetFramework as other projects

### DIFF
--- a/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
+++ b/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   
   <PropertyGroup>
     <AndroidTargetFramework>monoandroid90</AndroidTargetFramework>

--- a/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
+++ b/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
@@ -1,4 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+  <PropertyGroup Condition="$(XamarinFormsPackageVersion.StartsWith('5.0'))">
+    <AndroidTargetFramework>monoandroid10.0</AndroidTargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(iOSTargetFramework);$(AndroidTargetFramework)</TargetFrameworks>
     <Description>ArcGIS Runtime Augmented Reality controls and utilities for Xamarin.Forms Android and iOS apps</Description>

--- a/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
+++ b/src/ARToolkit.Forms/Esri.ArcGISRuntime.ARToolkit.Forms.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
-  
-  <PropertyGroup>
-    <AndroidTargetFramework>monoandroid90</AndroidTargetFramework>
-    <iOSTargetFramework>xamarinios10</iOSTargetFramework>
-    <UWPTargetFramework>uap10.0.17134</UWPTargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(iOSTargetFramework);$(AndroidTargetFramework)</TargetFrameworks>
     <Description>ArcGIS Runtime Augmented Reality controls and utilities for Xamarin.Forms Android and iOS apps</Description>

--- a/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
+++ b/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
@@ -1,4 +1,8 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+  <PropertyGroup>
+    <AndroidTargetFramework>monoandroid81</AndroidTargetFramework>
+  </PropertyGroup>
+
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(iOSTargetFramework);$(AndroidTargetFramework)</TargetFrameworks>
     <Description>ArcGIS Runtime Augmented Reality controls and utilities for Xamarin.Android and Xamarin.iOS apps.</Description>

--- a/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
+++ b/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
@@ -1,11 +1,4 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
-  
-  <PropertyGroup>
-    <AndroidTargetFramework>monoandroid81</AndroidTargetFramework>
-    <iOSTargetFramework>xamarinios10</iOSTargetFramework>
-    <UWPTargetFramework>uap10.0.17134</UWPTargetFramework>
-  </PropertyGroup>
-
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(iOSTargetFramework);$(AndroidTargetFramework)</TargetFrameworks>
     <Description>ArcGIS Runtime Augmented Reality controls and utilities for Xamarin.Android and Xamarin.iOS apps.</Description>

--- a/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
+++ b/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
   
   <PropertyGroup>
     <AndroidTargetFramework>monoandroid81</AndroidTargetFramework>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,7 +35,7 @@
     <DotNetTargetFramework>net461</DotNetTargetFramework>
     <UWPTargetFramework>uap10.0.17134</UWPTargetFramework>
     <NetCoreTargetFramework>netcoreapp3.1</NetCoreTargetFramework>
-	<NetWindowsTargetFramework>net5.0-windows10.0.18362.0</NetWindowsTargetFramework>
+    <NetWindowsTargetFramework>net5.0-windows10.0.18362.0</NetWindowsTargetFramework>
 
     <ArcGISRuntimePackageVersion Condition="'$(ArcGISRuntimePackageVersion)'==''">100.10.0</ArcGISRuntimePackageVersion>
     <XamarinFormsPackageVersion Condition="'$(XamarinFormsPackageVersion)'==''">4.8.0.1687</XamarinFormsPackageVersion>

--- a/src/Toolkit.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
+++ b/src/Toolkit.Forms/Esri.ArcGISRuntime.Toolkit.Xamarin.Forms.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/2.1.2">
+  <PropertyGroup Condition="$(XamarinFormsPackageVersion.StartsWith('5.0'))">
+    <AndroidTargetFramework>monoandroid10.0</AndroidTargetFramework>
+  </PropertyGroup>
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;$(iOSTargetFramework);$(UWPTargetFramework);$(AndroidTargetFramework)</TargetFrameworks>


### PR DESCRIPTION
Attempting to fix CI build error, complaining about version mismatch.
> Esri.ArcGISRuntime.ARToolkit.Forms -> \~\output\intermediate\arcgis-toolkit-dotnet\Output\Esri.ArcGISRuntime.ARToolkit.Forms\Release\xamarinios10\Esri.ArcGISRuntime.ARToolkit.Forms.dll
\~\output\intermediate\NugetPackageCache\xamarin.forms\5.0.0.1874\buildTransitive\Xamarin.Forms.targets(188,5): error XF005: The $(TargetFrameworkVersion) for Esri.ArcGISRuntime.ARToolkit.Forms (v9.0) is less than the minimum required $(TargetFrameworkVersion) for Xamarin.Forms (10.0). You need to increase the $(TargetFrameworkVersion) for Esri.ArcGISRuntime.ARToolkit.Forms. [\~\output\intermediate\arcgis-toolkit-dotnet\src\ARToolkit.Forms\Esri.ArcGISRuntime.ARToolkit.Forms.csproj]