### PR TITLE
Fixed initial heading getting overwritten in Initial and Continuous tracking modes on Android

### DIFF
--- a/src/ARToolkit/ARSceneView.cs
+++ b/src/ARToolkit/ARSceneView.cs
@@ -156,8 +156,14 @@ namespace Esri.ArcGISRuntime.ARToolkit
                 var locationPoint = e.Position;
                 if (_locationTrackingMode == ARLocationTrackingMode.Initial || !_initialLocationSet)
                 {
+#if __ANDROID__
+                    double heading = _initialHeading ?? 0;
+#else
+                    double heading = 0;
+#endif
+
                     // if location has altitude, use that else use a default value
-                    var newCamera = new Mapping.Camera(locationPoint.Y, locationPoint.X, locationPoint.HasZ ? locationPoint.Z : 1, 0, 90, 0);
+                    var newCamera = new Mapping.Camera(locationPoint.Y, locationPoint.X, locationPoint.HasZ ? locationPoint.Z : 1, heading, 90, 0);
                     OriginCamera = newCamera;
                     _initialLocationSet = true;
                 }

--- a/src/ARToolkit/ARSceneView.cs
+++ b/src/ARToolkit/ARSceneView.cs
@@ -156,12 +156,7 @@ namespace Esri.ArcGISRuntime.ARToolkit
                 var locationPoint = e.Position;
                 if (_locationTrackingMode == ARLocationTrackingMode.Initial || !_initialLocationSet)
                 {
-#if __ANDROID__
-                    double heading = _initialHeading ?? 0;
-#else
-                    double heading = 0;
-#endif
-
+                    double heading = OriginCamera.Heading;
                     // if location has altitude, use that else use a default value
                     var newCamera = new Mapping.Camera(locationPoint.Y, locationPoint.X, locationPoint.HasZ ? locationPoint.Z : 1, heading, 90, 0);
                     OriginCamera = newCamera;


### PR DESCRIPTION
In my testing, when `ARSceneView` is configured with `NorthAlign` set to `true` and tracking mode set to `Initial` or `Continuous` then aligning using compass doesn't work properly on Android.
`OrientationHelper_OrientationChanged` gets called first setting `OriginCamera` with initial heading, then `LocationDataSource_LocationChanged` gets called, overwriting initial heading with zero.

In this pull request I propose a simple fix to this problem. I'm not entirely sure this is the best solution, maybe some kind of boolean flag and lock preventing initial heading from overwriting would do better.

Tested on POCO X3 NFC phone, running Android 11.