### PR TITLE
iOS - Redraw compass on resize

### DIFF
--- a/src/Toolkit/Toolkit.iOS/UI/Controls/Compass/Compass.iOS.cs
+++ b/src/Toolkit/Toolkit.iOS/UI/Controls/Compass/Compass.iOS.cs
@@ -128,6 +128,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             context.DrawPath(CGPathDrawingMode.Fill);
         }
 
+        /// <inheritdoc/>
+        public override void LayoutSubviews()
+        {
+            base.LayoutSubviews();
+
+            // Ensure that the view is re-rendered upon resize
+            SetNeedsDisplay();
+        }
+
         private void UpdateCompassRotation(bool transition)
         {
             if (AutoHide)


### PR DESCRIPTION
As reported in #373, the compass was not re-drawing after resize on iOS, resulting in a blurry appearance. Because Forms uses the underlying platform view, Forms on iOS was also affected.

This change ensures that the view is redrawn when the size changes.