### PR TITLE
SymbolDisplay - Remove async void

### DIFF
--- a/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.Windows.cs
@@ -45,7 +45,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
         {
             base.OnApplyTemplate();
-            _ = Refresh();
+            Refresh();
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.Windows.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.Windows.cs
@@ -45,7 +45,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 #endif
         {
             base.OnApplyTemplate();
-            Refresh();
+            _ = Refresh();
         }
 
         /// <summary>

--- a/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.cs
@@ -68,17 +68,17 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 {
                     OnEventAction = (instance, source, eventArgs) =>
                     {
-                        _ = Refresh();
+                        Refresh();
                     },
                     OnDetachAction = (instance, weakEventListener) => instance.PropertyChanged -= weakEventListener.OnEvent,
                 };
                 newValue.PropertyChanged += _inpcListener.OnEvent;
             }
 
-            _ = Refresh();
+            Refresh();
         }
 
-        private async Task Refresh()
+        private async void Refresh()
         {
             try
             {

--- a/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SymbolDisplay/SymbolDisplay.cs
@@ -90,14 +90,13 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     return;
                 }
 
-                _isRefreshRequired = false;
-                var task = _currentUpdateTask = UpdateSwatchAsync();
-                await task;
-                _currentUpdateTask = null;
-                if (_isRefreshRequired)
+                do
                 {
-                    await Refresh();
-                }
+                    _isRefreshRequired = false;
+                    var task = _currentUpdateTask = UpdateSwatchAsync();
+                    await task;
+                } while (_isRefreshRequired);
+                _currentUpdateTask = null;
             }
             catch (Exception)
             {


### PR DESCRIPTION
This change makes the previously async void Refresh method return Task. The Windows implementation and other parts of the shared implementation are updated to discard the task.

Testing with Xamarin.Forms confirms that the previously-discovered crash no longer repros.