### PR TITLE
SearchView: Stay consistent with GeoView changes

### DIFF
--- a/src/Toolkit.Forms/SearchView/SearchView.cs
+++ b/src/Toolkit.Forms/SearchView/SearchView.cs
@@ -438,6 +438,8 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
                     }
                 }
 
+                sendingView.HandleViewpointChanged();
+
                 if (newValue is GeoView newGeoView)
                 {
                     (newGeoView as INotifyPropertyChanged).PropertyChanged += sendingView.HandleMapChange;
@@ -614,8 +616,15 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         /// </summary>
         private void HandleViewpointChanged()
         {
-            if (SearchViewModel == null || GeoView == null)
+            if (SearchViewModel == null)
             {
+                return;
+            }
+
+            if (GeoView == null)
+            {
+                SearchViewModel.QueryArea = null;
+                SearchViewModel.QueryCenter = null;
                 return;
             }
 

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchView.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchView.cs
@@ -274,6 +274,8 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     }
                 }
 
+                sender.HandleViewpointChanged();
+
                 if (e.NewValue is GeoView newGeoView)
                 {
                     (newGeoView as INotifyPropertyChanged).PropertyChanged += sender.HandleMapChange;
@@ -384,8 +386,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// </summary>
         private void HandleViewpointChanged()
         {
-            if (SearchViewModel == null || GeoView == null)
+            if (SearchViewModel == null)
             {
+                return;
+            }
+
+            if (GeoView == null)
+            {
+                SearchViewModel.QueryArea = null;
+                SearchViewModel.QueryCenter = null;
                 return;
             }
 

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -166,6 +166,10 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                     double newAvgSize = (newView.Width + newView.Height) / 2;
                     IsEligibleForRequery = distance > threshold || newAvgSize > avgSize * 1.25 || newAvgSize < avgSize * 0.75;
                 }
+                else if (value == null)
+                {
+                    IsEligibleForRequery = false;
+                }
             }
         }
 


### PR DESCRIPTION
Previously, if the bound geoview was removed while 'IsEligibleForRequery' was true, that property would never update.

With these changes, `IsEligibleForRequery` is set to false when a GeoView is removed, and the state is recalculated when a new geoview is added.