### PR TITLE
TimeSlider improvements

### DIFF
--- a/docs/controls.md
+++ b/docs/controls.md
@@ -83,6 +83,8 @@ Renders a symbol in a control.
 
 Allows interactively defining a temporal range (i.e. time extent) and animating time moving forward or backward.  Can be used to manipulate the time extent in a MapView or SceneView.
 
+![TimeSlider on UWP](https://user-images.githubusercontent.com/29742178/147712751-6d6db182-3e72-4dfc-ba23-3fbe97b1f934.png)
+
 
 ## Feature availability by platform/API
 
@@ -103,5 +105,5 @@ Allows interactively defining a temporal range (i.e. time extent) and animating 
 |SignInForm   |   | Preview |   |   |   |
 |SymbolDisplay   | ✔ | ✔ | ✔ | ✔ | ✔ |
 |TableOfContents   | N/A | Preview | N/A  | N/A | N/A |
-|TimeSlider   | ✔ | ✔ | ✔ | ✔ | ✔ |
+|[TimeSlider](time-slider.md)   | ✔ | ✔ | ✔ | ✔ | ✔ |
 

--- a/docs/time-slider.md
+++ b/docs/time-slider.md
@@ -1,0 +1,61 @@
+# TimeSlider 
+
+TimeSlider allows you to animate or manually step through a time range, with options to configure based on a time-aware layer or a GeoView.
+
+![TimeSlider on UWP](https://user-images.githubusercontent.com/29742178/147712751-6d6db182-3e72-4dfc-ba23-3fbe97b1f934.png)
+
+## Features
+
+- Supports stepping through the time extent with pre-defined steps. Steps can be customized.
+- Supports animating, with play and pause functionality, the time extent
+- Raises events when the time slider's time extent changes
+- Supports initialization of the slider from a layer or a GeoView.
+
+## Key API
+
+The following API methods, events, and properties are available to configure, interact, and respond to the time slider.
+
+See the API reference for full details.
+
+### Time control
+
+- `CurrentExtentChanged` - Raised when the current time extent in the slider changes. Listen to this if you want to update a GeoView's time extent.
+- `InitializeTimePropertiesAsync` - Initializes various properties, including full extent and time intervals, based on the GeoModel displayed by a GeoView, or a time-aware layer.
+- `InitializeTimeSteps` - Divides the slider into a specific number of steps
+- `FullExtent` - Full time range for the slider
+- `CurrentExtent` - Currently selected time range within the slider
+- `TimeStepInterval` - Duration of a time step
+- `TimeSteps` - Quantity of time steps
+- `IsStartTimePinned` - Controls whether selected start time can be changed
+- `IsEndTimePinned` - Controls whether selected end time can be changed
+
+### Playback
+
+- `IsPlaying` - Gets or sets a value indicating whether the time slider is animating
+- `PlaybackInterval` - Controls how long (in user time) the time slider waits before stepping the current extent when `IsPlaying` is true.
+- `PlaybackDirection` - Controls whether playback is moving forward or backward
+- `PlaybackLoopMode` - Controls the behavior whent the time slider reaches the end of the animation
+
+### Labeling
+
+- `LabelMode` - Controls how intervals and extents are labeled
+- `FullExtentLabelFormat` - Controls the format for the extent labels
+- `CurrentExtentLabelFormat` - Controls the format for the current extent labels
+- `TimeStepIntervalLabelFormat` - Controls the format for the interval labels
+
+## Usage
+
+Note: following code assumes that `TimeSlider` has already been added to the view alongside a `MapView`.
+
+```cs
+private async Task InitializeSliderAsync()
+{
+    timeSlider.CurrentExtentChanged += Slider_CurrentExtentChanged;
+    await timeSlider.InitializeTimePropertiesAsync(mapView);
+}
+
+private void Slider_CurrentExtentChanged(object sender, UI.TimeExtentChangedEventArgs e)
+{
+    mapView.TimeExtent = e.NewExtent;
+}
+```

--- a/docs/time-slider.md
+++ b/docs/time-slider.md
@@ -34,7 +34,7 @@ See the API reference for full details.
 - `IsPlaying` - Gets or sets a value indicating whether the time slider is animating
 - `PlaybackInterval` - Controls how long (in user time) the time slider waits before stepping the current extent when `IsPlaying` is true.
 - `PlaybackDirection` - Controls whether playback is moving forward or backward
-- `PlaybackLoopMode` - Controls the behavior whent the time slider reaches the end of the animation
+- `PlaybackLoopMode` - Controls the behavior when the time slider reaches the end of the animation
 
 ### Labeling
 

--- a/src/Samples/Toolkit.SampleApp.Android/Resources/layout/TimeSliderSample.axml
+++ b/src/Samples/Toolkit.SampleApp.Android/Resources/layout/TimeSliderSample.axml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Esri.ArcGISRuntime.UI.Controls.MapView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:id="@+id/mapView" />
+    <Esri.ArcGISRuntime.Toolkit.UI.Controls.TimeSlider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/timeSlider" />
+    <LinearLayout android:orientation="horizontal"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent">
+        <Button android:text="Choose a Layer"
+            android:layout_width="wrap_content" 
+            android:layout_height="wrap_content"
+            android:id="@+id/layerButton"/>
+        <Button android:text="Configure Intervals"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/stepIntervalButton" />
+        <TextView android:text="No layer selected"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/statusLabel" />
+    </LinearLayout>
+    <LinearLayout android:orientation="horizontal"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent">
+        <Button android:text="Step Back" 
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/stepBackButton" />
+        <Button android:text="Step Forward" 
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/stepForwardButton" />
+    </LinearLayout>
+</LinearLayout>

--- a/src/Samples/Toolkit.SampleApp.Android/Samples/TimeSliderSample.cs
+++ b/src/Samples/Toolkit.SampleApp.Android/Samples/TimeSliderSample.cs
@@ -21,7 +21,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples
         private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
         {
             {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
-            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+            {"Human Life Expectancy", new Uri("https://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
         };
 
         private MapView _mapView;

--- a/src/Samples/Toolkit.SampleApp.Android/Samples/TimeSliderSample.cs
+++ b/src/Samples/Toolkit.SampleApp.Android/Samples/TimeSliderSample.cs
@@ -1,0 +1,172 @@
+﻿using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Widget;
+using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples
+{
+    [Activity(Label = "TimeSlider", ConfigurationChanges = Android.Content.PM.ConfigChanges.Orientation)]
+    [SampleInfoAttribute(Category = "TimeSlider", Description = "TimeSlider used with a MapView")]
+    public class TimeSliderSample : Activity
+    {
+        private Map _map { get; } = new Map(Basemap.CreateLightGrayCanvas());
+
+        private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
+        {
+            {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
+            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+        };
+
+        private MapView _mapView;
+        private TimeSlider _timeSlider;
+        private Button _stepForwardButton;
+        private Button _stepBackButton;
+        private Button _stepIntervalButton;
+        private Button _layerButton;
+        private TextView _statusLabel;
+
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            SetContentView(Resource.Layout.TimeSliderSample);
+            _mapView = FindViewById<MapView>(Resource.Id.mapView);
+            _timeSlider = FindViewById<TimeSlider>(Resource.Id.timeSlider);
+            _stepForwardButton = FindViewById<Button>(Resource.Id.stepForwardButton);
+            _stepBackButton = FindViewById<Button>(Resource.Id.stepBackButton);
+            _stepIntervalButton = FindViewById<Button>(Resource.Id.stepIntervalButton);
+            _layerButton = FindViewById<Button>(Resource.Id.layerButton);
+            _statusLabel = FindViewById<TextView>(Resource.Id.statusLabel);
+
+            _stepForwardButton.Click += StepForward_Click;
+            _stepBackButton.Click += StepBack_Click;
+            _stepIntervalButton.Click += StepInterval_Click;
+            _layerButton.Click += LayerButton_Click;
+
+            _mapView.Map = _map;
+            _timeSlider.CurrentExtentChanged += Slider_CurrentExtentChanged;
+            _statusLabel.Text = "No layer selected";
+        }
+
+        private void Slider_CurrentExtentChanged(object sender, Esri.ArcGISRuntime.Toolkit.UI.TimeExtentChangedEventArgs e)
+        {
+            _mapView.TimeExtent = e.NewExtent;
+        }
+
+        private void StepForward_Click(object sender, EventArgs e)
+        {
+            GetInput("Step forward", "How many steps? Leave blank for one.", (input) =>
+            {
+                if (int.TryParse(input, out int steps))
+                {
+                    _timeSlider.StepForward(steps);
+                }
+                else
+                {
+                    _timeSlider.StepForward();
+                }
+            });
+        }
+
+        private void StepBack_Click(object sender, EventArgs e)
+        {
+            GetInput("Step back", "How many steps? Leave blank for one.", (input) =>
+            {
+                if (int.TryParse(input, out int steps))
+                {
+                    _timeSlider.StepBack(steps);
+                }
+                else
+                {
+                    _timeSlider.StepBack();
+                }
+            });
+        }
+
+        private void StepInterval_Click(object sender, EventArgs e)
+        {
+            GetInput("Set Interval Count", "How many intervals?", (input) =>
+            {
+                if (int.TryParse(input, out int steps))
+                {
+                    _timeSlider.InitializeTimeSteps(steps);
+                }
+                else
+                {
+                    ShowMessage("Invalid input", "Couldn't parse integer");
+                }
+            });
+        }
+
+        private void LayerButton_Click(object sender, EventArgs e)
+        {
+            StartLayerSelection();
+        }
+
+        private async Task HandleSelectionChanged(string key)
+        {
+            _map.OperationalLayers.Clear();
+            var layer = new FeatureLayer(_namedLayers[key]);
+            _map.OperationalLayers.Add(layer);
+            await _timeSlider.InitializeTimePropertiesAsync(layer);
+
+            _statusLabel.Text = layer.SupportsTimeFiltering ? "Time supported" : "No time support";
+        }
+
+        // Function shows an alert to get input, then calls callback with value
+        private void GetInput(string title, string message, Action<string> callback)
+        {
+            var alert = new AlertDialog.Builder(this);
+            alert.SetTitle(title);
+            alert.SetMessage(message);
+
+            var input = new EditText(this);
+            alert.SetView(input);
+
+            alert.SetPositiveButton("Ok", (senderAlert, args) =>
+            {
+                callback(input.Text);
+            });
+
+            alert.SetNegativeButton("Cancel", (senderAlert, args) =>
+            {
+                callback(null);
+            });
+
+            alert.Show();
+        }
+
+
+        // Show alert to choose from a list of options, and call callback with value
+        private void StartLayerSelection()
+        {
+            var alert = new AlertDialog.Builder(this);
+            alert.SetTitle("Choose layer to display");
+
+            var keys = _namedLayers.Keys.ToList();
+
+            // Add list of options to alert
+            alert.SetSingleChoiceItems(keys.ToArray(), 0, (senderAlert, args) =>
+            {
+                _ = HandleSelectionChanged(keys[args.Which]);
+            });
+
+            alert.SetPositiveButton("Ok", (IDialogInterfaceOnClickListener)null);
+
+            alert.Show();
+        }
+
+        private void ShowMessage(string message, string title)
+        {
+            // Display the message to the user.
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder.SetMessage(message).SetTitle(title).Show();
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
+++ b/src/Samples/Toolkit.SampleApp.Android/Toolkit.Samples.Android.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SampleScreenAdapter.cs" />
     <Compile Include="Samples\BookmarksViewSample.cs" />
+    <Compile Include="Samples\TimeSliderSample.cs" />
     <Compile Include="Samples\CompassSceneViewSample.cs" />
     <Compile Include="Samples\LayerLegendSample.cs" />
     <Compile Include="Samples\LegendSample.cs" />
@@ -139,6 +140,12 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\BookmarksViewSample.axml">
+      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
+      <SubType>Designer</SubType>
+    </AndroidResource>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\layout\TimeSliderSample.axml">
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
       <SubType>Designer</SubType>
     </AndroidResource>

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml
@@ -1,0 +1,107 @@
+﻿<Page
+    x:Class="Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.TimeSlider.TimeSliderSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:esri="using:Esri.ArcGISRuntime.UI.Controls"
+    xmlns:esriToolkit="using:Esri.ArcGISRuntime.Toolkit.UI.Controls"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <StackPanel Orientation="Vertical">
+            <StackPanel.Resources>
+                <Style TargetType="Border">
+                    <Setter Property="Padding" Value="4" />
+                    <Setter Property="BorderThickness" Value="0,1,0,0" />
+                    <Setter Property="BorderBrush" Value="{ThemeResource ApplicationForegroundThemeBrush}" />
+                </Style>
+            </StackPanel.Resources>
+            <Border>
+                <StackPanel>
+                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="Choose Layer" />
+                    <ComboBox x:Name="LayerSelectionBox" HorizontalAlignment="Stretch" />
+                </StackPanel>
+            </Border>
+            <Border>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.ColumnSpan="2"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Step forward and back" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Text="Intervals to step:" />
+                    <TextBox
+                        x:Name="StepCountBox"
+                        Grid.Row="2"
+                        Grid.ColumnSpan="2"
+                        Text="1" />
+                    <Button
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Click="StepBack_Click"
+                        Content="Step Back" />
+                    <Button
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Click="StepForward_Click"
+                        Content="Step Forward" />
+                </Grid>
+            </Border>
+            <Border>
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="Choose Interval Count" />
+                    <TextBox x:Name="IntervalCountBox" Text="?" />
+                    <Button Click="ConfigureIntervals_Click" Content="Configure Intervals" />
+                </StackPanel>
+            </Border>
+            <Border Padding="4">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="Status" />
+                    <TextBlock>
+                        <Run Text="Layer supports time filtering?  " />
+                        <Run x:Name="IsTimeAwareLabel" />
+                    </TextBlock>
+                </StackPanel>
+            </Border>
+            <Border Padding="4">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="Notes" />
+                    <TextBlock Text="TimeSlider is transparent by default" TextWrapping="Wrap" />
+                    <TextBlock Text="TimeSlider needs additional configuration not in XAML. See code-behind for details." TextWrapping="Wrap" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+
+        <esri:MapView
+            x:Name="mapView"
+            Grid.Column="1"
+            Map="{x:Bind Map, Mode=OneTime}" />
+
+        <Border
+            Grid.Column="1"
+            MaxWidth="300"
+            Margin="8"
+            Padding="4"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            <esriToolkit:TimeSlider x:Name="slider" />
+        </Border>
+    </Grid>
+</Page>

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml
@@ -9,7 +9,7 @@
     mc:Ignorable="d">
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="220" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <StackPanel Orientation="Vertical">
@@ -54,11 +54,13 @@
                     <Button
                         Grid.Row="3"
                         Grid.Column="0"
+                        HorizontalAlignment="Stretch"
                         Click="StepBack_Click"
                         Content="Step Back" />
                     <Button
                         Grid.Row="3"
                         Grid.Column="1"
+                        HorizontalAlignment="Stretch"
                         Click="StepForward_Click"
                         Content="Step Forward" />
                 </Grid>
@@ -67,7 +69,10 @@
                 <StackPanel Orientation="Vertical">
                     <TextBlock Style="{ThemeResource CaptionTextBlockStyle}" Text="Choose Interval Count" />
                     <TextBox x:Name="IntervalCountBox" Text="?" />
-                    <Button Click="ConfigureIntervals_Click" Content="Configure Intervals" />
+                    <Button
+                        HorizontalAlignment="Stretch"
+                        Click="ConfigureIntervals_Click"
+                        Content="Configure Intervals" />
                 </StackPanel>
             </Border>
             <Border Padding="4">

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml.cs
@@ -15,7 +15,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.TimeSlider
         private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
         {
             {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
-            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+            {"Human Life Expectancy", new Uri("https://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
         };
 
         public TimeSliderSample()

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/TimeSlider/TimeSliderSample.xaml.cs
@@ -1,0 +1,93 @@
+﻿using Esri.ArcGISRuntime.Mapping;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Windows.UI.Popups;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.TimeSlider
+{
+    public sealed partial class TimeSliderSample : Page
+    {
+        public Map Map { get; } = new Map(Basemap.CreateLightGrayCanvas());
+
+        private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
+        {
+            {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
+            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+        };
+
+        public TimeSliderSample()
+        {
+            InitializeComponent();
+            slider.CurrentExtentChanged += Slider_CurrentExtentChanged;
+            this.DataContext = this;
+            LayerSelectionBox.ItemsSource = _namedLayers.Keys;
+            LayerSelectionBox.SelectedIndex = 0;
+            _ = HandleSelectionChanged();
+            LayerSelectionBox.SelectionChanged += LayerSelectionBox_SelectionChanged;
+        }
+
+        private void Slider_CurrentExtentChanged(object sender, UI.TimeExtentChangedEventArgs e)
+        {
+            mapView.TimeExtent = e.NewExtent;
+        }
+
+        private void LayerSelectionBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            _ = HandleSelectionChanged();
+        }
+
+        private async Task HandleSelectionChanged()
+        {
+            Map.OperationalLayers.Clear();
+            var selectedLayer = LayerSelectionBox.SelectedItem.ToString();
+
+            var layer = new FeatureLayer(_namedLayers[selectedLayer]);
+            Map.OperationalLayers.Add(layer);
+            await slider.InitializeTimePropertiesAsync(layer);
+
+            IsTimeAwareLabel.Text = layer.SupportsTimeFiltering ? "Yes" : "No";
+        }
+
+        private void StepForward_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(StepCountBox.Text);
+                slider.StepForward(intervals);
+            }
+            catch (Exception ex)
+            {
+                _ = new MessageDialog(ex.Message).ShowAsync();
+            }
+        }
+
+        private void StepBack_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(StepCountBox.Text);
+                slider.StepBack(intervals);
+            }
+            catch (Exception ex)
+            {
+                _ = new MessageDialog(ex.Message).ShowAsync();
+            }
+        }
+
+        private void ConfigureIntervals_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(IntervalCountBox.Text);
+                slider.InitializeTimeSteps(intervals);
+            }
+            catch (Exception ex)
+            {
+                _ = new MessageDialog(ex.Message).ShowAsync();
+            }
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
+++ b/src/Samples/Toolkit.SampleApp.UWP/Toolkit.Samples.UWP.csproj
@@ -136,6 +136,9 @@
     <Compile Include="Samples\Compass\MapViewCompassSample.xaml.cs">
       <DependentUpon>MapViewCompassSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\TimeSlider\TimeSliderSample.xaml.cs">
+      <DependentUpon>TimeSliderSample.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Samples\Compass\SceneViewCompassSample.xaml.cs">
       <DependentUpon>SceneViewCompassSample.xaml</DependentUpon>
     </Compile>
@@ -218,6 +221,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Samples\BookmarksView\BookmarksViewSample.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Samples\TimeSlider\TimeSliderSample.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml
@@ -1,16 +1,86 @@
-﻿<UserControl x:Class="Esri.ArcGISRuntime.Toolkit.Samples.TimeSlider.TimeSliderSample"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Esri.ArcGISRuntime.Toolkit.Samples.TimeSlider"
-             xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
-             mc:Ignorable="d" Language="da-DK"
-             d:DesignHeight="450" d:DesignWidth="800">
+﻿<UserControl
+    x:Class="Esri.ArcGISRuntime.Toolkit.Samples.TimeSlider.TimeSliderSample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:esri="http://schemas.esri.com/arcgis/runtime/2013"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
     <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <StackPanel Orientation="Vertical">
+            <GroupBox Header="Choose Layer">
+                <ComboBox x:Name="LayerSelectionBox" />
+            </GroupBox>
+            <GroupBox Header="Step forward and back">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.ColumnSpan="2" Content="Intervals to step:" />
+                    <TextBox
+                        x:Name="StepCountBox"
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Text="1" />
+                    <Button
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Click="StepBack_Click"
+                        Content="Step Back" />
+                    <Button
+                        Grid.Row="2"
+                        Grid.Column="1"
+                        Click="StepForward_Click"
+                        Content="Step Forward" />
+                </Grid>
+            </GroupBox>
+            <GroupBox Header="Choose Interval Count">
+                <StackPanel Orientation="Vertical">
+                    <TextBox x:Name="IntervalCountBox" Text="?" />
+                    <Button Click="ConfigureIntervals_Click" Content="Configure Intervals" />
+                </StackPanel>
+            </GroupBox>
+            <GroupBox Padding="4" Header="Status">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock>
+                        <Run Text="Layer supports time filtering?  " />
+                        <Run x:Name="IsTimeAwareLabel" />
+                    </TextBlock>
+                </StackPanel>
+            </GroupBox>
+            <GroupBox Padding="4" Header="Notes">
+                <StackPanel Orientation="Vertical">
+                    <TextBlock Text="TimeSlider is transparent by default" TextWrapping="Wrap" />
+                    <TextBlock Text="TimeSlider needs additional configuration not in XAML. See code-behind for details." TextWrapping="Wrap" />
+                </StackPanel>
+            </GroupBox>
+        </StackPanel>
 
-        <esri:MapView Map="{Binding Map}" x:Name="mapView" />
+        <esri:MapView
+            x:Name="mapView"
+            Grid.Column="1"
+            Map="{Binding Map}" />
 
-        <esri:TimeSlider x:Name="slider" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="20" MaxWidth="300" CurrentExtent="10/12/2017" />
+        <Border
+            Grid.Column="1"
+            MaxWidth="300"
+            Margin="8"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Background="White">
+            <esri:TimeSlider x:Name="slider" CurrentExtent="10/12/2017" />
+        </Border>
     </Grid>
 </UserControl>

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml
@@ -77,6 +77,7 @@
             Grid.Column="1"
             MaxWidth="300"
             Margin="8"
+            Padding="4"
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
             Background="White">

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/TimeSlider/TimeSliderSample.xaml.cs
@@ -14,7 +14,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.TimeSlider
         private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
         {
             {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
-            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+            {"Human Life Expectancy", new Uri("https://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
         };
 
         public TimeSliderSample()

--- a/src/Samples/Toolkit.SampleApp.iOS/Samples/TimeSliderController.cs
+++ b/src/Samples/Toolkit.SampleApp.iOS/Samples/TimeSliderController.cs
@@ -1,0 +1,187 @@
+﻿using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI.Controls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using UIKit;
+
+namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples
+{
+    [SampleInfoAttribute(Category = "TimeSlider", DisplayName = "TimeSlider", Description = "TimeSlider used with a MapView")]
+    public partial class TimeSliderViewController : UIViewController
+    {
+        MapView _mapView;
+        TimeSlider _timeSlider;
+        UISegmentedControl _layerSegment;
+        Map _map = new Map(Basemap.CreateLightGrayCanvas());
+        UIBarButtonItem _stepForwardButton;
+        UIBarButtonItem _stepBackButton;
+        UIBarButtonItem _stepCountButton;
+        UIAlertController _textInputAlertController;
+        UILabel _statusLabel;
+
+        private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
+        {
+            {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
+            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+        };
+
+        private async Task HandleSelectionChanged()
+        {
+            _map.OperationalLayers.Clear();
+            var layers = _namedLayers.Keys.ToList();
+            var selectedLayer = _namedLayers[layers.ElementAt((int)_layerSegment.SelectedSegment)];
+
+            var layer = new FeatureLayer(selectedLayer);
+            _map.OperationalLayers.Add(layer);
+            await _timeSlider.InitializeTimePropertiesAsync(layer);
+
+            _statusLabel.Text = layer.SupportsTimeFiltering ? "Time supported for current layer." : "Time not supported for current layer.";
+        }
+
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            View.BackgroundColor = UIColor.SystemBackgroundColor;
+
+            _mapView = new MapView()
+            {
+                Map = _map,
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            _timeSlider = new TimeSlider
+            {
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            _layerSegment = new UISegmentedControl
+            {
+                TranslatesAutoresizingMaskIntoConstraints = false
+            };
+
+            foreach(var layer in _namedLayers.Keys.Reverse())
+            {
+                _layerSegment.InsertSegment(layer, 0, false);
+            }
+
+            var toolbar = new UIToolbar { TranslatesAutoresizingMaskIntoConstraints = false };
+
+            _stepCountButton = new UIBarButtonItem("Adjust step count", null);
+            _stepForwardButton = new UIBarButtonItem(UIBarButtonSystemItem.FastForward);
+            _stepBackButton = new UIBarButtonItem(UIBarButtonSystemItem.Rewind);
+
+            toolbar.Items = new[]
+            {
+                _stepCountButton,
+                new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace),
+                _stepBackButton,
+                _stepForwardButton
+            };
+
+            _statusLabel = new UILabel
+            {
+                TranslatesAutoresizingMaskIntoConstraints = false,
+                BackgroundColor = UIColor.FromWhiteAlpha(0f, 0.6f),
+                TextColor = UIColor.White,
+                TextAlignment = UITextAlignment.Center,
+                Text = "Select a layer to begin.",
+                Lines = 1,
+                AdjustsFontSizeToFitWidth = true
+            };
+
+            View.AddSubviews(_mapView, _timeSlider, toolbar, _layerSegment, _statusLabel);
+
+            NSLayoutConstraint.ActivateConstraints(new []
+            {
+                _mapView.TopAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TopAnchor),
+                _mapView.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+                _mapView.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor),
+                _mapView.BottomAnchor.ConstraintEqualTo(_timeSlider.TopAnchor),
+                _layerSegment.CenterXAnchor.ConstraintEqualTo(_mapView.CenterXAnchor),
+                _layerSegment.TopAnchor.ConstraintEqualTo(_statusLabel.BottomAnchor, 8),
+                _timeSlider.LeadingAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.LeadingAnchor),
+                _timeSlider.TrailingAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.TrailingAnchor),
+                _timeSlider.BottomAnchor.ConstraintEqualTo(toolbar.TopAnchor),
+                _timeSlider.HeightAnchor.ConstraintEqualTo(100),
+                toolbar.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+                toolbar.BottomAnchor.ConstraintEqualTo(View.SafeAreaLayoutGuide.BottomAnchor),
+                toolbar.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor),
+                _statusLabel.LeadingAnchor.ConstraintEqualTo(View.LeadingAnchor),
+                _statusLabel.TrailingAnchor.ConstraintEqualTo(View.TrailingAnchor),
+                _statusLabel.TopAnchor.ConstraintEqualTo(_mapView.TopAnchor),
+                _statusLabel.HeightAnchor.ConstraintEqualTo(40)
+            });
+        }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            _timeSlider.CurrentExtentChanged += _timeSlider_CurrentExtentChanged;
+            _layerSegment.ValueChanged += _layerSegment_ValueChanged;
+            _stepForwardButton.Clicked += _stepForwardButton_Clicked;
+            _stepBackButton.Clicked += _stepBackButton_Clicked;
+            _stepCountButton.Clicked += _stepCountButton_Clicked;
+            base.ViewWillAppear(animated);
+        }
+
+        private void _stepCountButton_Clicked(object sender, EventArgs e)
+        {
+            if (_textInputAlertController == null)
+            {
+                _textInputAlertController = UIAlertController.Create("Set number of time steps to show.", "", UIAlertControllerStyle.Alert);
+                _textInputAlertController.AddTextField(textField => { textField.KeyboardType = UIKeyboardType.NumberPad; });
+
+                void HandleAlertAction(UIAlertAction action)
+                {
+                    try
+                    {
+                        var intervals = int.Parse(_textInputAlertController.TextFields[0].Text);
+                        _timeSlider.InitializeTimeSteps(intervals);
+                    }
+                    catch(Exception)
+                    {
+                        // Ignore
+                    }
+                }
+
+                // Add Actions.
+                _textInputAlertController.AddAction(UIAlertAction.Create("Done", UIAlertActionStyle.Default, HandleAlertAction));
+            }
+
+            // Show the alert.
+            PresentViewController(_textInputAlertController, true, null);
+        }
+
+        private void _stepBackButton_Clicked(object sender, EventArgs e)
+        {
+            _timeSlider.StepBack(1);
+        }
+
+        private void _stepForwardButton_Clicked(object sender, EventArgs e)
+        {
+            _timeSlider.StepForward(1);
+        }
+
+        private void _layerSegment_ValueChanged(object sender, EventArgs e)
+        {
+            _ = HandleSelectionChanged();
+        }
+
+        private void _timeSlider_CurrentExtentChanged(object sender, UI.TimeExtentChangedEventArgs e)
+        {
+            _mapView.TimeExtent = e.NewExtent;
+        }
+
+        public override void ViewDidDisappear(bool animated)
+        {
+            _timeSlider.CurrentExtentChanged -= _timeSlider_CurrentExtentChanged;
+            _layerSegment.ValueChanged -= _layerSegment_ValueChanged;
+            _stepBackButton.Clicked -= _stepBackButton_Clicked;
+            _stepForwardButton.Clicked -= _stepForwardButton_Clicked;
+            _stepCountButton.Clicked -= _stepCountButton_Clicked;
+            base.ViewDidDisappear(animated);
+        }
+    }
+}

--- a/src/Samples/Toolkit.SampleApp.iOS/Samples/TimeSliderController.cs
+++ b/src/Samples/Toolkit.SampleApp.iOS/Samples/TimeSliderController.cs
@@ -25,7 +25,7 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples
         private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
         {
             {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
-            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+            {"Human Life Expectancy", new Uri("https://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
         };
 
         private async Task HandleSelectionChanged()

--- a/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
+++ b/src/Samples/Toolkit.SampleApp.iOS/Toolkit.Samples.iOS.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Samples\BookmarksView\BookmarksModalSampleViewController.cs" />
     <Compile Include="Samples\BookmarksView\BookmarksMapEventTestController.cs" />
     <Compile Include="Samples\BookmarksView\BookmarksViewSceneViewViewController.cs" />
+    <Compile Include="Samples\TimeSliderController.cs" />
     <Compile Include="Samples\LayerLegendViewController.cs" />
     <Compile Include="Samples\LegendViewController.cs" />
     <Compile Include="Samples\ScaleLineViewController.cs" />

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Toolkit.Samples.Forms.Samples.TimeSliderSample"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:esriTK="clr-namespace:Esri.ArcGISRuntime.Toolkit.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Toolkit.Xamarin.Forms"
+    xmlns:esriUI="clr-namespace:Esri.ArcGISRuntime.Xamarin.Forms;assembly=Esri.ArcGISRuntime.Xamarin.Forms"
+    Title="TimeSlider">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="200" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <esriUI:MapView
+                x:Name="mapView"
+                Grid.Row="0"
+                Grid.Column="1" />
+            <esriTK:TimeSlider
+                x:Name="slider"
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2" />
+
+            <StackLayout Grid.Row="0" Grid.Column="0">
+                <Label Text="Choose Layer" />
+                <Picker x:Name="LayerSelectionBox" HorizontalOptions="FillAndExpand" />
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.ColumnSpan="2" Text="Step forward and back" />
+                    <Label
+                        Grid.Row="1"
+                        Grid.ColumnSpan="2"
+                        Text="Intervals to step:" />
+                    <Entry
+                        x:Name="StepCountBox"
+                        Grid.Row="2"
+                        Grid.ColumnSpan="2"
+                        Text="1" />
+                    <Button
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Clicked="StepBack_Click"
+                        Text="Step Back" />
+                    <Button
+                        Grid.Row="3"
+                        Grid.Column="1"
+                        Clicked="StepForward_Click"
+                        Text="Step Forward" />
+                </Grid>
+                <Label Text="Choose Interval Count" />
+                <Entry x:Name="IntervalCountBox" Text="?" />
+                <Button Clicked="ConfigureIntervals_Click" Text="Configure Intervals" />
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Layer supports time filtering?  " />
+                    <Label x:Name="IsTimeAwareLabel" />
+                </StackLayout>
+                <Label Text="Notes" />
+                <Label Text="TimeSlider is transparent by default" />
+                <Label Text="TimeSlider needs additional configuration not in XAML. See code-behind for details." />
+            </StackLayout>
+
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml.cs
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml.cs
@@ -1,0 +1,96 @@
+﻿using Esri.ArcGISRuntime.Mapping;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Toolkit.Samples.Forms.Samples
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    [SampleInfoAttribute(Category = "TimeSlider", Description = "TimeSlider")]
+    public partial class TimeSliderSample : ContentPage
+    {
+        public Map Map { get; } = new Map(Basemap.CreateLightGrayCanvas());
+
+        private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
+        {
+            {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
+            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+        };
+
+        public TimeSliderSample()
+        {
+            InitializeComponent();
+            mapView.Map = this.Map;
+            slider.CurrentExtentChanged += Slider_CurrentExtentChanged;
+            LayerSelectionBox.ItemsSource = _namedLayers.Keys.ToList();
+            LayerSelectionBox.SelectedIndex = 0;
+            _ = HandleSelectionChanged();
+            LayerSelectionBox.SelectedIndexChanged += LayerSelectionBox_SelectedIndexChanged;
+        }
+
+        private void Slider_CurrentExtentChanged(object sender, Esri.ArcGISRuntime.Toolkit.UI.TimeExtentChangedEventArgs e)
+        {
+            mapView.TimeExtent = e.NewExtent;
+        }
+
+        private void LayerSelectionBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            _ = HandleSelectionChanged();
+        }
+
+        private async Task HandleSelectionChanged()
+        {
+            Map.OperationalLayers.Clear();
+            var selectedLayer = LayerSelectionBox.SelectedItem.ToString();
+
+            var layer = new FeatureLayer(_namedLayers[selectedLayer]);
+            Map.OperationalLayers.Add(layer);
+            await slider.InitializeTimePropertiesAsync(layer);
+
+            IsTimeAwareLabel.Text = layer.SupportsTimeFiltering ? "Yes" : "No";
+        }
+
+        private void StepForward_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(StepCountBox.Text);
+                slider.StepForward(intervals);
+            }
+            catch (Exception ex)
+            {
+                this.DisplayAlert("Error", ex.Message, "Ok");
+            }
+        }
+
+        private void StepBack_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(StepCountBox.Text);
+                slider.StepBack(intervals);
+            }
+            catch (Exception ex)
+            {
+                this.DisplayAlert("Error", ex.Message, "Ok");
+            }
+        }
+
+        private void ConfigureIntervals_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var intervals = int.Parse(IntervalCountBox.Text);
+                slider.InitializeTimeSteps(intervals);
+            }
+            catch (Exception ex)
+            {
+                this.DisplayAlert("Error", ex.Message, "Ok");
+            }
+        }
+    }
+}

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml.cs
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/TimeSliderSample.xaml.cs
@@ -18,7 +18,7 @@ namespace Toolkit.Samples.Forms.Samples
         private Dictionary<string, Uri> _namedLayers = new Dictionary<string, Uri>
         {
             {"Hurricanes", new Uri("https://services.arcgis.com/XSeYKQzfXnEgju9o/ArcGIS/rest/services/Hurricanes_1950_to_2015/FeatureServer/0") },
-            {"Human Life Expectancy", new Uri("http://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
+            {"Human Life Expectancy", new Uri("https://services1.arcgis.com/VAI453sU9tG9rSmh/arcgis/rest/services/WorldGeo_HumanCulture_LifeExpectancy_features/FeatureServer/0") }
         };
 
         public TimeSliderSample()

--- a/src/Toolkit.Forms/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit.Forms/TimeSlider/TimeSlider.cs
@@ -29,7 +29,8 @@ using Windows.UI.Xaml.Media;
 namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
 {
     /// <summary>
-    /// The Compass Control showing the heading on the map when the rotation is not North up / 0.
+    /// The TimeSlider is a utility Control that emits TimeExtent values typically for use with the Map Control
+    /// to enhance the viewing of geographic features that have attributes based upon Date/Time information.
     /// </summary>
     public class TimeSlider : View
     {
@@ -220,7 +221,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
             BindableProperty.Create(nameof(FullExtent), typeof(TimeExtent), typeof(TimeSlider), null, BindingMode.OneWay, null, OnFullExtentPropertyChanged);
 
         /// <summary>
-        /// Gets or sets the <see cref="TimeExtent" /> associated with the visual thumbs(s) displayed on the TimeSlider.
+        /// Gets or sets the <see cref="TimeExtent" /> that specifies the overall start and end time of the time slider instance.
         /// </summary>
         public TimeExtent? FullExtent
         {
@@ -251,7 +252,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
             BindableProperty.Create(nameof(TimeStepInterval), typeof(TimeValue), typeof(TimeSlider), null, BindingMode.OneWay, null, OnTimeStepIntervalPropertyChanged);
 
         /// <summary>
-        /// Gets or sets the <see cref="TimeValue" /> associated with the visual thumbs(s) displayed on the TimeSlider.
+        /// Gets or sets the time step intervals for the time slider.  The slider thumbs will snap to and tick marks will be shown at this interval.
         /// </summary>
         public TimeValue? TimeStepInterval
         {

--- a/src/Toolkit.Forms/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit.Forms/TimeSlider/TimeSlider.cs
@@ -965,7 +965,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Xamarin.Forms
         /// <summary>
         /// Updates the time slider to have the specified number of time steps.
         /// </summary>
-        /// <param name="count">The number of time steps.</param>
+        /// <param name="count">The number of time steps. Values less than one are ignored.</param>
         /// <remarks>This method divides the TimeSlider instance's <see cref="FullExtent"/> into the number of steps specified,
         /// updating the <see cref="TimeStepInterval"/> and <see cref="TimeSteps"/> properties.  The method will attempt to set
         /// the interval to a TimeValue with the smallest duration and largest time unit that will fit evenly (i.e. without

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
@@ -161,19 +161,6 @@
                                                         Background="Transparent"
                                                         BorderBrush="Transparent" 
                                                         BorderThickness="0">
-                                                    <Grid Margin="1" Background="Transparent">
-                                                        <Border x:Name="BackgroundAnimation" Opacity="0" Background="#FF448DCA"/>
-                                                        <Rectangle x:Name="BackgroundGradient">
-                                                            <Rectangle.Fill>
-                                                                <LinearGradientBrush EndPoint=".7,1" StartPoint=".7,0">
-                                                                    <GradientStop Color="#FFFFFFFF" Offset="0"/>
-                                                                    <GradientStop Color="#F9FFFFFF" Offset="0.375"/>
-                                                                    <GradientStop Color="#E5FFFFFF" Offset="0.625"/>
-                                                                    <GradientStop Color="#C6FFFFFF" Offset="1"/>
-                                                                </LinearGradientBrush>
-                                                            </Rectangle.Fill>
-                                                        </Rectangle>
-                                                    </Grid>
                                                 </Border>
                                                 <Grid HorizontalAlignment="Center"
                                                       Margin="{TemplateBinding Padding}"

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
@@ -276,7 +276,6 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <!-- Corrects layout issues that would otherwise happen. -->
 						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="0" />
 						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="1" />
 						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="2" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/TimeSlider/TimeSlider.Theme.xaml
@@ -276,6 +276,13 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
+                        <!-- Corrects layout issues that would otherwise happen. -->
+						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="0" />
+						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="1" />
+						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="2" />
+						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="3" />
+						<Border Background="{TemplateBinding Background}" Grid.RowSpan="4" Grid.Column="4" />
+
                         <!-- start time label -->
                         <TextBlock x:Name="FullExtentStartTimeLabel"
                                    Text="{Binding FullExtent.StartTime,

--- a/src/Toolkit/Toolkit/Internal/TimeExtensions.cs
+++ b/src/Toolkit/Toolkit/Internal/TimeExtensions.cs
@@ -213,21 +213,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
                 // The full time extent cannot be divided into a non-fractional time step interval.  Fall back to the smallest fractional
                 // time step interval with a unit of days or less that is greater than one.  Avoid units of months or greater since the
                 // temporal value of a fractional month is dependent on when in the calendar year the value is applied.
-                if (millisecondsPerTimeStep / millisecondsPerSecond > 1)
+                if (millisecondsPerTimeStep / millisecondsPerDay > 1)
                 {
-                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerSecond), TimeUnit.Seconds);
-                }
-                else if (millisecondsPerTimeStep / millisecondsPerMinute > 1)
-                {
-                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerMinute), TimeUnit.Minutes);
+                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerDay, TimeUnit.Days);
                 }
                 else if (millisecondsPerTimeStep / millisecondsPerHour > 1)
                 {
-                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerHour), TimeUnit.Hours);
+                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerHour, TimeUnit.Hours);
                 }
-                else if (millisecondsPerTimeStep / millisecondsPerDay > 1)
+                else if (millisecondsPerTimeStep / millisecondsPerMinute > 1)
                 {
-                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerDay), TimeUnit.Days);
+                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerMinute, TimeUnit.Minutes);
+                }
+                else if (millisecondsPerTimeStep / millisecondsPerSecond > 1)
+                {
+                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerSecond, TimeUnit.Seconds);
                 }
                 else
                 {

--- a/src/Toolkit/Toolkit/Internal/TimeExtensions.cs
+++ b/src/Toolkit/Toolkit/Internal/TimeExtensions.cs
@@ -213,21 +213,21 @@ namespace Esri.ArcGISRuntime.Toolkit.Internal
                 // The full time extent cannot be divided into a non-fractional time step interval.  Fall back to the smallest fractional
                 // time step interval with a unit of days or less that is greater than one.  Avoid units of months or greater since the
                 // temporal value of a fractional month is dependent on when in the calendar year the value is applied.
-                if (millisecondsPerTimeStep / millisecondsPerDay > 1)
+                if (millisecondsPerTimeStep / millisecondsPerSecond > 1)
                 {
-                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerDay, TimeUnit.Days);
-                }
-                else if (millisecondsPerTimeStep / millisecondsPerHour > 1)
-                {
-                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerHour, TimeUnit.Hours);
+                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerSecond), TimeUnit.Seconds);
                 }
                 else if (millisecondsPerTimeStep / millisecondsPerMinute > 1)
                 {
-                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerMinute, TimeUnit.Minutes);
+                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerMinute), TimeUnit.Minutes);
                 }
-                else if (millisecondsPerTimeStep / millisecondsPerSecond > 1)
+                else if (millisecondsPerTimeStep / millisecondsPerHour > 1)
                 {
-                    return new TimeValue(millisecondsPerTimeStep / millisecondsPerSecond, TimeUnit.Seconds);
+                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerHour), TimeUnit.Hours);
+                }
+                else if (millisecondsPerTimeStep / millisecondsPerDay > 1)
+                {
+                    return new TimeValue((int)(millisecondsPerTimeStep / millisecondsPerDay), TimeUnit.Days);
                 }
                 else
                 {

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -1323,7 +1323,15 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <returns>Task.</returns>
         public async Task InitializeTimePropertiesAsync(GeoView? geoView)
         {
-            if (geoView is null)
+            if (geoView is MapView mv && mv.Map != null)
+            {
+                await mv.Map.LoadAsync();
+            }
+            else if (geoView is SceneView sv && sv.Scene != null)
+            {
+                await sv.Scene.LoadAsync();
+            }
+            else if (geoView is null)
             {
                 throw new ArgumentNullException(nameof(geoView));
             }
@@ -1367,7 +1375,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             // If the geoview has a temporal extent defined, use that.  Otherwise, initialize the current extent to either the
             // full extent's start (if instantaneous time-filtering can be used), or to the entire full extent.
-            CurrentExtent = geoView.TimeExtent == null ? geoView.TimeExtent : fullExtent is null ? null : canUseInstantaneousTime ?
+            CurrentExtent = geoView.TimeExtent != null ? geoView.TimeExtent : fullExtent is null ? null : canUseInstantaneousTime ?
                 new TimeExtent(fullExtent.StartTime) : new TimeExtent(fullExtent.StartTime, fullExtent.EndTime);
         }
 

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -1290,7 +1290,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Updates the time slider to have the specified number of time steps.
         /// </summary>
-        /// <param name="count">The number of time steps.</param>
+        /// <param name="count">The number of time steps. Values less than one are ignored.</param>
         /// <remarks>This method divides the TimeSlider instance's <see cref="FullExtent"/> into the number of steps specified,
         /// updating the <see cref="TimeStepInterval"/> and <see cref="TimeSteps"/> properties.  The method will attempt to set
         /// the interval to a TimeValue with the smallest duration and largest time unit that will fit evenly (i.e. without
@@ -1301,7 +1301,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Note that, if the TimeSlider instance's FullExtent property is not set, invoking this method will have no effect.</remarks>
         public void InitializeTimeSteps(int count)
         {
-            if (FullExtent == null)
+            if (FullExtent == null || count < 1)
             {
                 return;
             }

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -857,6 +857,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             for (var nextStep = startTime.AddTimeValue(timeStep); nextStep <= endTime; nextStep = nextStep.AddTimeValue(timeStep))
             {
+                // TODO = come up with a more rigorous definition or expose API
+                if (endTime.Subtract(nextStep).TotalMinutes < 10)
+                {
+                    nextStep = endTime;
+                }
+
                 steps.Add(nextStep);
             }
 

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -857,13 +857,18 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             for (var nextStep = startTime.AddTimeValue(timeStep); nextStep <= endTime; nextStep = nextStep.AddTimeValue(timeStep))
             {
-                // TODO = come up with a more rigorous definition or expose API
-                if (endTime.Subtract(nextStep).TotalMinutes < 10)
+                steps.Add(nextStep);
+            }
+
+            if (steps.LastOrDefault() is DateTimeOffset lastTime && lastTime < endTime)
+            {
+                // if difference is less than half a step, replace the last step with the end time
+                if (endTime.Subtract(lastTime).TotalMilliseconds < (timeStep.ToMilliseconds() / 2))
                 {
-                    nextStep = endTime;
+                    steps.Remove(steps.Last());
                 }
 
-                steps.Add(nextStep);
+                steps.Add(endTime);
             }
 
             TimeSteps = steps.AsReadOnly();

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -1296,7 +1296,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Updates the time slider to have the specified number of time steps.
         /// </summary>
-        /// <param name="count">The number of time steps. Values less than one are ignored.</param>
+        /// <param name="count">The number of time steps.</param>
         /// <remarks>This method divides the TimeSlider instance's <see cref="FullExtent"/> into the number of steps specified,
         /// updating the <see cref="TimeStepInterval"/> and <see cref="TimeSteps"/> properties.  The method will attempt to set
         /// the interval to a TimeValue with the smallest duration and largest time unit that will fit evenly (i.e. without
@@ -1307,7 +1307,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// Note that, if the TimeSlider instance's FullExtent property is not set, invoking this method will have no effect.</remarks>
         public void InitializeTimeSteps(int count)
         {
-            if (FullExtent == null || count < 1)
+            if (count < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            if (FullExtent == null)
             {
                 return;
             }

--- a/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/TimeSlider/TimeSlider.cs
@@ -1413,9 +1413,6 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
 
             if (timeStepInterval != null)
             {
-                // Check whether the time-aware layer supports filtering based on a time instant
-                var canUseInstantaneousTime = await CanUseInstantaneousTimeAsync(timeAwareLayer);
-
                 // Apply full extent and time step interval to slider properties
                 FullExtent = fullExtent;
                 TimeStepInterval = timeStepInterval;
@@ -1423,8 +1420,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
                 // TODO: Double-check whether we can choose a better default for current extent - does not seem to be exposed
                 // at all in service metadata
                 CurrentExtent = fullExtent is null ? null :
-                    canUseInstantaneousTime || TimeSteps is null ?
-                    new TimeExtent(fullExtent.StartTime) : new TimeExtent(fullExtent.StartTime, TimeSteps.ElementAt(1));
+                    TimeSteps is null ? new TimeExtent(fullExtent.StartTime) : new TimeExtent(fullExtent.StartTime, TimeSteps.ElementAt(1));
 
                 // TODO: Initialize time-zone (will require converting time zone string to strong type)
             }


### PR DESCRIPTION
This PR takes a first step towards improving the TimeSlider and the developer experience.

Changes include:

- Improved WPF sample to better exercise the capabilities of the control
- Added samples for UWP, Xamarin.Forms, iOS, and Android
- Updated the markdown doc to have a page on time slider, which highlights useful API
- Updated other markdown documentation to include a picture
- Fixed some API reference content for the Xamarin.Forms implementation
- Fixed the issue where a white rectangle was shown behind the play/pause button on WPF
- Fixed a layout issue where the thumb and right-most part of the slider track were being clipped on WPF
- Adds a check for time step counts less than one, which would previously cause strange behavior.
- ⚠️ Partially fixed an issue where time handling code was causing some time intervals to be left off of the slider. These changes are in TimeSlider.cs and TimeExtensions.cs and are the riskiest changes in the PR. To see the benefit, you can manually set the time steps; before the change, with the time-aware layer in the sample, step counts of 7, 11, 13, 17, 19, 21, and 29  would result in steps being left off the slider. With this change, all steps are present.
- Fixes an issue where initializing the time slider from a GeoView wouldn't work if the map or scene wasn't already loaded.
- Fixes an issue where initializing the time slider from a GeoView would not update the slider's current extent if the GeoView's current extent was already null.

Follow up issues will be logged to address design issues, further sample improvements, and testing needs.