### PR TITLE
SearchView: Implement selection notification, add test/sample

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml
@@ -74,6 +74,8 @@
                     HorizontalAlignment="Stretch"
                     Click="RemoveLocator_Click"
                     Content="Remove Last Search Source" />
+                <Button Click="AddTestLocator_Click" Content="Add event test search source" />
+                <TextBlock Text="Expectation: test locator shows message when results (de)selected" TextWrapping="Wrap" />
             </StackPanel>
         </Border>
     </Grid>

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/SearchView/SearchViewCustomizationSample.xaml.cs
@@ -1,6 +1,12 @@
-﻿using Esri.ArcGISRuntime.Mapping;
+﻿using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Windows.UI.Popups;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -64,6 +70,68 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.SearchView
                     MySearchView.SearchViewModel.SearchMode = SearchResultMode.Multiple;
                     break;
             }
+        }
+
+        private void AddTestLocator_Click(object sender, RoutedEventArgs e)
+        {
+            MySearchView.SearchViewModel.Sources.Add(new TestSearchSource());
+        }
+
+        private class TestSearchSource : ISearchSource
+        {
+            public string DisplayName { get => "Event tester"; set => throw new NotImplementedException(); }
+            public string Placeholder { get => "Test placeholder"; set => throw new NotImplementedException(); }
+            public CalloutDefinition DefaultCalloutDefinition { get => null; set => throw new NotImplementedException(); }
+            public double DefaultZoomScale { get => 1000; set => throw new NotImplementedException(); }
+            public int MaximumResults { get => 3; set => throw new NotImplementedException(); }
+            public int MaximumSuggestions { get => 3; set => throw new NotImplementedException(); }
+            public Geometry.Geometry SearchArea { get => null; set { } }
+            public MapPoint PreferredSearchLocation { get => null; set { } }
+
+            Symbology.Symbol ISearchSource.DefaultSymbol { get => null; set => throw new NotImplementedException(); }
+
+            public void NotifyDeselected(SearchResult result)
+            {
+                _ = new MessageDialog($"Deselected {result?.DisplayTitle ?? "all results"}").ShowAsync();
+            }
+
+            public void NotifySelected(SearchResult result)
+            {
+                _ = new MessageDialog($"Selected {result?.DisplayTitle}").ShowAsync();
+            }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            public async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Envelope queryExtent, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchResult($"repeat {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchResult($"explicit search {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken)
+            {
+                if (suggestion.IsCollection)
+                {
+                    var list = new[] { "one", "two", "three", "four" };
+                    return list.Select(m => new SearchResult($"search from suggestion - res: {m}", suggestion.DisplayTitle, this, null, null)).ToList();
+                }
+                else
+                {
+                    return new List<SearchResult>() { new SearchResult($"result from suggestion {suggestion.DisplayTitle}", "from suggestion", this, null, null) };
+                }
+            }
+
+            public async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchSuggestion($"suggestion {m}", this) { IsCollection = m.Contains("w") }).ToList();
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         }
     }
 }

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/SearchView/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/SearchView/SearchViewCustomizationSample.xaml
@@ -77,6 +77,8 @@
                 <Button Click="AddSMPLocator_Click" Content="Add Locator from StreetMap Premium MMPK:" />
                 <TextBox x:Name="LocatorPathText" Text="Path ex:C:\Greater_Los_Angeles.mmpk" />
                 <Button Click="RemoveLocator_Click" Content="Remove Last Search Source" />
+                <Button Click="AddTestLocator_Click" Content="Add event test search source" />
+                <TextBlock Text="Expectation: test locator shows message when results (de)selected" TextWrapping="Wrap" />
             </StackPanel>
         </Border>
     </Grid>

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/SearchView/SearchViewCustomizationSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/SearchView/SearchViewCustomizationSample.xaml.cs
@@ -1,8 +1,15 @@
+using Esri.ArcGISRuntime.Geometry;
 using Esri.ArcGISRuntime.Mapping;
+using Esri.ArcGISRuntime.Symbology;
 using Esri.ArcGISRuntime.Tasks.Geocoding;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -89,6 +96,67 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.SearchView
                     MySearchView.SearchViewModel.SearchMode = SearchResultMode.Multiple;
                     break;
             }
+        }
+
+        private void AddTestLocator_Click(object sender, RoutedEventArgs e)
+        {
+            MySearchView.SearchViewModel.Sources.Add(new TestSearchSource());
+        }
+
+        private class TestSearchSource : ISearchSource
+        {
+            public string DisplayName { get => "Event tester"; set => throw new NotImplementedException(); }
+            public string Placeholder { get => "Test placeholder"; set => throw new NotImplementedException(); }
+            public CalloutDefinition DefaultCalloutDefinition { get => null; set => throw new NotImplementedException(); }
+            public Symbol DefaultSymbol { get => null; set => throw new NotImplementedException(); }
+            public double DefaultZoomScale { get => 1000; set => throw new NotImplementedException(); }
+            public int MaximumResults { get => 3; set => throw new NotImplementedException(); }
+            public int MaximumSuggestions { get => 3; set => throw new NotImplementedException(); }
+            public Geometry.Geometry SearchArea { get => null; set { } }
+            public MapPoint PreferredSearchLocation { get => null; set { } }
+
+            public void NotifyDeselected(SearchResult result)
+            {
+                MessageBox.Show($"Deselected {result?.DisplayTitle ?? "all results"}");
+            }
+
+            public void NotifySelected(SearchResult result)
+            {
+                MessageBox.Show($"Selected {result.DisplayTitle}");
+            }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            public async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Envelope queryExtent, CancellationToken cancellationToken)
+            {
+                var list = new [] {"one", "two", "three", "four"};
+                return list.Select(m => new SearchResult($"repeat {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new [] {"one", "two", "three", "four"};
+                return list.Select(m => new SearchResult($"explicit search {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken)
+            {
+                if (suggestion.IsCollection)
+                {
+                    var list = new [] {"one", "two", "three", "four"};
+                    return list.Select(m => new SearchResult($"search from suggestion - res: {m}", suggestion.DisplayTitle, this, null, null)).ToList();
+                }
+                else
+                {
+                    return new List<SearchResult>() { new SearchResult($"result from suggestion {suggestion.DisplayTitle}", "from suggestion", this, null, null)};
+                }
+            }
+
+            public async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new [] {"one", "two", "three", "four"};
+                return list.Select(m => new SearchSuggestion($"suggestion {m}", this) { IsCollection = m.Contains("w")}).ToList();
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         }
     }
 }

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/SearchViewCustomizationSample.xaml
@@ -95,6 +95,7 @@
                     <Button Clicked="AddDefaultLocator_Click" Text="Add World Geocoder with Name:" />
                     <Entry x:Name="GeocoderNameEntry" Text="Name" />
                     <Button Clicked="RemoveLocator_Click" Text="Remove Last Search Source" />
+                    <Button Clicked="AddTestLocator_Click" Text="Add event test source" />
                 </StackLayout>
             </ScrollView>
         </Grid>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/SearchViewCustomizationSample.xaml.cs
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/SearchViewCustomizationSample.xaml.cs
@@ -1,6 +1,12 @@
-﻿using Esri.ArcGISRuntime.Mapping;
+﻿using Esri.ArcGISRuntime.Geometry;
+using Esri.ArcGISRuntime.Mapping;
 using Esri.ArcGISRuntime.Toolkit.UI.Controls;
+using Esri.ArcGISRuntime.UI;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -65,6 +71,68 @@ namespace Toolkit.Samples.Forms.Samples
                     MySearchView.SearchViewModel.SearchMode = SearchResultMode.Multiple;
                     break;
             }
+        }
+
+        private void AddTestLocator_Click(object sender, EventArgs e)
+        {
+            MySearchView.SearchViewModel.Sources.Add(new TestSearchSource());
+        }
+
+        private class TestSearchSource : ISearchSource
+        {
+            public string DisplayName { get => "Event tester"; set => throw new NotImplementedException(); }
+            public string Placeholder { get => "Test placeholder"; set => throw new NotImplementedException(); }
+            public CalloutDefinition DefaultCalloutDefinition { get => null; set => throw new NotImplementedException(); }
+            public double DefaultZoomScale { get => 1000; set => throw new NotImplementedException(); }
+            public int MaximumResults { get => 3; set => throw new NotImplementedException(); }
+            public int MaximumSuggestions { get => 3; set => throw new NotImplementedException(); }
+            public Geometry SearchArea { get => null; set { } }
+            public MapPoint PreferredSearchLocation { get => null; set { } }
+
+            Esri.ArcGISRuntime.Symbology.Symbol ISearchSource.DefaultSymbol { get => null; set => throw new NotImplementedException(); }
+
+            public void NotifyDeselected(SearchResult result)
+            {
+                App.Current.MainPage.DisplayAlert("Deselected", $"Deselected {result?.DisplayTitle ?? "all results"}", "Ok");
+            }
+
+            public void NotifySelected(SearchResult result)
+            {
+                App.Current.MainPage.DisplayAlert("Selected", $"Selected {result?.DisplayTitle}", "Ok");
+            }
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+            public async Task<IList<SearchResult>> RepeatSearchAsync(string queryString, Envelope queryExtent, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchResult($"repeat {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchResult($"explicit search {m}", "repeat subtitle", this, null, null)).ToList();
+            }
+
+            public async Task<IList<SearchResult>> SearchAsync(SearchSuggestion suggestion, CancellationToken cancellationToken)
+            {
+                if (suggestion.IsCollection)
+                {
+                    var list = new[] { "one", "two", "three", "four" };
+                    return list.Select(m => new SearchResult($"search from suggestion - res: {m}", suggestion.DisplayTitle, this, null, null)).ToList();
+                }
+                else
+                {
+                    return new List<SearchResult>() { new SearchResult($"result from suggestion {suggestion.DisplayTitle}", "from suggestion", this, null, null) };
+                }
+            }
+
+            public async Task<IList<SearchSuggestion>> SuggestAsync(string queryString, CancellationToken cancellationToken)
+            {
+                var list = new[] { "one", "two", "three", "four" };
+                return list.Select(m => new SearchSuggestion($"suggestion {m}", this) { IsCollection = m.Contains("w") }).ToList();
+            }
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         }
     }
 }

--- a/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/SearchView/SearchViewModel.cs
@@ -98,7 +98,24 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
         /// <summary>
         /// Gets or sets the selected search result.
         /// </summary>
-        public SearchResult? SelectedResult { get => _selectedResult; set => SetPropertyChanged(value, ref _selectedResult); }
+        public SearchResult? SelectedResult
+        {
+            get => _selectedResult;
+            set
+            {
+                if (_selectedResult != null)
+                {
+                    _selectedResult.OwningSource.NotifyDeselected(_selectedResult);
+                }
+
+                SetPropertyChanged(value, ref _selectedResult);
+
+                if (value != null)
+                {
+                    value.OwningSource.NotifySelected(value);
+                }
+            }
+        }
 
         /// <summary>
         /// Gets or sets the current query.


### PR DESCRIPTION
Background:

- `ISearchSource` defines methods that should be called by the consuming `SearchView`/`SearchViewModel` whenever a result is selected.
- Notification of selection is required for some workflows to be handled by the search source; e.g. selecting the correct floor to match a selected search result, or selecting a feature corresponding to a search result on the map

This PR:

- Updates `SearchViewModel` to call `NotifySelected`/`NotifyDeselected` on the relevant search source when the selected search result changes.
- Updates the existing customization sample on UWP, WPF, and Forms to include a custom search source for testing the selection behavior.