### PR TITLE
Update docfx TOC to include new topics

### DIFF
--- a/docs/concepts/toc.yml
+++ b/docs/concepts/toc.yml
@@ -9,9 +9,17 @@
   items:
   - name: List of controls
     href: ../controls.md
-  - name: Bookmarks View
-    href: ../bookmarks-view.md
   - name: Augmented Reality View
     href: ../ar.md
+  - name: Basemap Gallery
+    href: ../basemap-gallery.md
+  - name: Bookmarks View
+    href: ../bookmarks-view.md
+  - name: Overview Map
+    href: ../overview-map.md
+  - name: Search View
+    href: ../search-view.md
+  - name: Time Slider
+    href: ../time-slider.md
 - name: API Reference
   href: ../api/index.md


### PR DESCRIPTION
This PR updates the docfx configuration to fix two issues:

- Documentation for new controls wasn't shown in the navigation
- Documentation for newer controls didn't have the same sidebar as other controls
Built locally and everything looks good:

![image](https://user-images.githubusercontent.com/29742178/156454311-52ffe5d2-335d-4dbb-a8f6-34671b383baf.png)
