### PR TITLE
Update ARCore, restore Android hit test behavior

### DIFF
--- a/src/ARSamples/ARToolkit.SampleApp.Android/ARToolkit.SampleApp.Android.csproj
+++ b/src/ARSamples/ARToolkit.SampleApp.Android/ARToolkit.SampleApp.Android.csproj
@@ -138,7 +138,7 @@
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5-rc3" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Xamarin.Google.ARCore">
-      <Version>1.26.0</Version>
+      <Version>1.29.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ARSamples/ARToolkit.Samples.Forms.Android/ARToolkit.Samples.Forms.Android.csproj
+++ b/src/ARSamples/ARToolkit.Samples.Forms.Android/ARToolkit.Samples.Forms.Android.csproj
@@ -77,7 +77,7 @@
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.1.0" />
     <PackageReference Include="Xamarin.Google.ARCore">
-      <Version>1.26.0</Version>
+      <Version>1.29.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/ARToolkit/ARSceneView.Android.cs
+++ b/src/ARToolkit/ARSceneView.Android.cs
@@ -356,9 +356,13 @@ namespace Esri.ArcGISRuntime.ARToolkit
                 var hitResults = frame.HitTest(screenPoint.X, screenPoint.Y);
                 foreach (var item in hitResults)
                 {
-                    var t = item.HitPose.GetTranslation();
-                    var r = item.HitPose.GetRotationQuaternion();
-                    return TransformationMatrix.Create(r[0], r[1], r[2], r[3], t[0], t[1], t[2]);
+                    if (item.Trackable is Plane pl && pl.IsPoseInPolygon(item.HitPose) ||
+                        item.Trackable is Point pnt && pnt.GetOrientationMode() == Point.OrientationMode.EstimatedSurfaceNormal)
+                    {
+                        var t = item.HitPose.GetTranslation();
+                        var r = item.HitPose.GetRotationQuaternion();
+                        return TransformationMatrix.Create(r[0], r[1], r[2], r[3], t[0], t[1], t[2]);
+                    }
                 }
             }
 

--- a/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
+++ b/src/ARToolkit/Esri.ArcGISRuntime.ARToolkit.csproj
@@ -29,7 +29,7 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == '$(AndroidTargetFramework)'">
     <PackageReference Include="Esri.ArcGISRuntime.Xamarin.Android" Version="$(ArcGISRuntimePackageVersion)" />
-    <PackageReference Include="Xamarin.Google.ARCore" Version="1.26.0" />
+    <PackageReference Include="Xamarin.Google.ARCore" Version="1.29.0" />
     <!--<PackageReference Include="Xamarin.Android.SceneForm.Base" Version="1.11.0" />-->
     <PackageReference Include="Xamarin.Android.SceneForm.UX" Version="1.17.1" />
     <AndroidResource Include="Resources\**\*.xml">

--- a/src/ProjectTemplates/ArcGISRuntime.AR/Template.Android/Android.csproj
+++ b/src/ProjectTemplates/ArcGISRuntime.AR/Template.Android/Android.csproj
@@ -100,7 +100,7 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.3" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.1" />
-    <PackageReference Include="Xamarin.Google.ARCore" Version="1.26.0" />
+    <PackageReference Include="Xamarin.Google.ARCore" Version="1.29.0" />
     <PackageReference Include="Esri.ArcGISRuntime.ARToolkit" Version="$(AGS_TOOLKIT_VERSION)" />
   </ItemGroup>
 


### PR DESCRIPTION
Due to a bug in the ARCore 1.26.0 Xamarin binding, hit test filtering had to be removed, which led to less accurate surface placement when there were multiple planes in view. This issue has been fixed in the 1.29.0 release.

This PR updates to 1.29.0 and restores the previous behavior.

I've tested both the Forms and native Android AR samples to confirm the behavior has been improved and everything else is working as expected.