### PR TITLE
BasemapGallery: improve loading behavior for better performance in common scenarios

### DIFF
--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml
@@ -48,6 +48,10 @@
                     Margin="0,4,0,4"
                     Click="Button_Add_Last"
                     Content="Add special items" />
+                <Button
+                    Margin="0,4,0,4"
+                    Click="Button_Add_WGS84"
+                    Content="Add WGS84 basemap" />
                 <Button Click="Button_Remove_Last" Content="Remove last item" />
                 <TextBlock Text="Currently selected Basemap:" />
                 <TextBlock Text="{Binding ElementName=Gallery, Path=SelectedBasemap.Name, Mode=OneWay}" />

--- a/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.UWP/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
@@ -87,6 +87,12 @@ namespace Esri.ArcGISRuntime.Toolkit.SampleApp.Samples.BasemapGallery
             Gallery.AvailableBasemaps.Add(item2);
         }
 
+        private async void Button_Add_WGS84(object sender, RoutedEventArgs e)
+        {
+            BasemapGalleryItem item = await BasemapGalleryItem.CreateAsync(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1396c369fa3b44a2a5437f18412f8032")));
+            Gallery.AvailableBasemaps.Add(item);
+        }
+
         private void Button_Remove_Last(object sender, RoutedEventArgs e)
         {
             if (Gallery.AvailableBasemaps.Any())

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml
@@ -38,6 +38,10 @@
                     Margin="0,4,0,4"
                     Click="Button_Add_Last"
                     Content="Add special items" />
+                <Button
+                    Margin="0,4,0,4"
+                    Click="Button_Add_WGS84"
+                    Content="Add WGS84 basemap" />
                 <Button Click="Button_Remove_Last" Content="Remove last item" />
                 <Label Content="Currently selected Basemap:" />
                 <Label Content="{Binding ElementName=Gallery, Path=SelectedBasemap.Name, Mode=OneWay}" />

--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/BasemapGallery/BasemapGalleryBehaviorSample.xaml.cs
@@ -116,6 +116,12 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.BasemapGallery
             Gallery.AvailableBasemaps.Add(item2);
         }
 
+        private async void Button_Add_WGS84(object sender, RoutedEventArgs e)
+        {
+            BasemapGalleryItem item = await BasemapGalleryItem.CreateAsync(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1396c369fa3b44a2a5437f18412f8032")));
+            Gallery.AvailableBasemaps.Add(item);
+        }
+
         private void Button_Remove_Last(object sender, RoutedEventArgs e)
         {
             if (Gallery.AvailableBasemaps.Any())

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/BasemapGalleryBehaviorSample.xaml
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/BasemapGalleryBehaviorSample.xaml
@@ -80,23 +80,27 @@
                     Grid.Column="1"
                     Clicked="Button_Remove_Last"
                     Text="Remove last item" />
+                <Button Grid.Row="5" Grid.Column="0"
+                    Margin="0,4,0,4"
+                    Clicked="Button_Add_WGS84"
+                    Text="Add WGS84" />
                 <Label
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.Column="0"
                     HorizontalTextAlignment="End"
                     Text="Selection:" />
                 <Label
-                    Grid.Row="5"
+                    Grid.Row="6"
                     Grid.Column="1"
                     Text="{Binding Source={x:Reference Gallery}, Path=SelectedBasemap.Name, FallbackValue='None', Mode=OneWay}" />
                 <Label
-                    Grid.Row="6"
+                    Grid.Row="7"
                     Grid.Column="0"
                     HorizontalTextAlignment="End"
                     Text="Basemap selection event last raised:" />
                 <Label
                     x:Name="LastSelectedDateLabel"
-                    Grid.Row="6"
+                    Grid.Row="7"
                     Grid.Column="1"
                     Text="Never" />
             </Grid>

--- a/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/BasemapGalleryBehaviorSample.xaml.cs
+++ b/src/Samples/Toolkit.Samples.Forms/Toolkit.Samples.Forms/Samples/BasemapGalleryBehaviorSample.xaml.cs
@@ -90,6 +90,12 @@ namespace Toolkit.Samples.Forms.Samples
             Gallery.AvailableBasemaps.Add(item2);
         }
 
+        private async void Button_Add_WGS84(object sender, EventArgs e)
+        {
+            BasemapGalleryItem item = await BasemapGalleryItem.CreateAsync(new Basemap(new Uri("https://www.arcgis.com/home/item.html?id=1396c369fa3b44a2a5437f18412f8032")));
+            Gallery.AvailableBasemaps.Add(item);
+        }
+
         private void Button_Remove_Last(object sender, EventArgs e)
         {
             if (Gallery.AvailableBasemaps.Any())

--- a/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
+++ b/src/Toolkit/Toolkit/UI/Controls/BasemapGallery/BasemapGalleryController.cs
@@ -298,20 +298,7 @@ namespace Esri.ArcGISRuntime.Toolkit.UI
                 listOfBasemaps.Add(new BasemapGalleryItem(item));
             }
 
-#if !WINDOWS_UWP && !NETCOREAPP && !NETCOREAPP3_1
             await Task.WhenAll(listOfBasemaps.Select(gi => gi.LoadAsync()));
-#else
-            foreach (var item in listOfBasemaps)
-            {
-                try
-                {
-                    await item.LoadAsync();
-                }
-                catch (Exception)
-                {
-                }
-            }
-#endif
 
             return listOfBasemaps;
         }


### PR DESCRIPTION
Changes:

- Adds samples to show behavior with incompatible basemap (WGS84)
- Removes workaround that applied to non-.NET Framework platforms; now all platforms load the basemap collection the same way.
- Updates BasemapGalleryItem loading behavior to separate basemap and thumbnail loading, and not block on thumbnail load
- Updated BasemapGalleryItem to defer the spatial reference check and only load the underlying map once there is a spatial reference to compare to.