### PR TITLE
WPF: limit listview multiple selection

### DIFF
--- a/src/Toolkit/Toolkit.WPF/UI/Controls/BasemapGallery/BasemapGallery.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/BasemapGallery/BasemapGallery.Theme.xaml
@@ -225,6 +225,7 @@
                                 VerticalAlignment="{TemplateBinding VerticalAlignment}"
                                 HorizontalContentAlignment="Stretch"
                                 Background="{TemplateBinding Background}"
+                                SelectionMode="Single"
                                 BorderThickness="0"
                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                                 <ListView.Resources>

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/FloorFilter/FloorFilter.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/FloorFilter/FloorFilter.Theme.xaml
@@ -244,6 +244,7 @@
     <Style x:Key="FloorFilterListStyle" TargetType="ListView">
         <Setter Property="Padding" Value="0" />
         <Setter Property="Margin" Value="0" />
+        <Setter Property="SelectionMode" Value="Single" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="Foreground" Value="{StaticResource FloorFilterDefaultForegroundBrush}" />

--- a/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
+++ b/src/Toolkit/Toolkit.WPF/UI/Controls/SearchView/SearchView.Theme.xaml
@@ -356,6 +356,7 @@
                                     ItemTemplate="{StaticResource SourceTemplate}"
                                     ItemsSource="{Binding SearchViewModel.Sources, Mode=OneWay}"
                                     SelectedItem="{Binding SearchViewModel.ActiveSource, Mode=TwoWay}"
+                                    SelectionMode="Single"
                                     Style="{StaticResource ListStyle}" />
                             </StackPanel>
                         </Border>
@@ -493,6 +494,7 @@
                                 ItemContainerStyle="{StaticResource ListContainerStyle}"
                                 ItemsSource="{Binding SearchViewModel.Results, Mode=OneWay}"
                                 SelectedItem="{Binding SearchViewModel.SelectedResult, Mode=OneWayToSource}"
+                                SelectionMode="Single"
                                 Style="{StaticResource ListStyle}">
                                 <ListView.ItemTemplate>
                                     <DataTemplate DataType="{x:Type controls:SearchResult}">


### PR DESCRIPTION
Before this PR, several controls failed to account for manual multiple selection in lists using the shift or control keys. This PR specifies single selection mode for ListViews on WPF.

Resolves #417. 