### PR TITLE
TOC - load map image sublayers for display in TOC

### DIFF
--- a/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/ToC/TableOfContentsSample.xaml.cs
+++ b/src/Samples/Toolkit.SampleApp.WPF_Net5/Samples/ToC/TableOfContentsSample.xaml.cs
@@ -27,7 +27,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Samples.ToC
                 InitialViewpoint = new Viewpoint(new Envelope(-178, 17.8, -65, 71.4, SpatialReference.Create(4269)))
             };
 
-            map.OperationalLayers.Add(new ArcGISMapImageLayer(new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer")));
+            map.OperationalLayers.Add(new ArcGISMapImageLayer(new Uri("https://apps.fs.usda.gov/arcx/rest/services/EDW/EDW_HydroFlowMetricsAbsChange2040_01/MapServer")));
             map.OperationalLayers.Add(new FeatureLayer(new Uri("https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/FeatureServer/0")));
 
             mapView.Map = map;

--- a/src/Toolkit.Preview/Toolkit.Preview/UI/TableOfContents/TocItem.cs
+++ b/src/Toolkit.Preview/Toolkit.Preview/UI/TableOfContents/TocItem.cs
@@ -59,6 +59,7 @@ namespace Esri.ArcGISRuntime.Toolkit.Preview.UI
                 if (content is ILoadable loadable && loadable.LoadStatus != LoadStatus.Loaded)
                 {
                     loadable.Loaded += (s, e) => SetChildren();
+                    _ = loadable.LoadAsync();
                 }
                 else
                 {


### PR DESCRIPTION
This PR addresses an issue where sublayers were not shown in the TOC.

Originally reported in Esri Community: https://community.esri.com/t5/arcgis-runtime-sdk-for-net-questions/toolkit-table-of-contents-doesn-t-show-group-layer/m-p/1169941#M10956

Resolves #423