### PR TITLE
Search - Fix layout issue affecting MAUI winUI

### DIFF
--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewCustomizationSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewCustomizationSample.xaml
@@ -13,7 +13,7 @@
         <Grid RowSpacing="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="{OnPlatform WinUI=400, Default=Auto}" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="150" />
             </Grid.RowDefinitions>

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSample.xaml
@@ -12,7 +12,7 @@
         <Grid RowSpacing="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="{OnPlatform WinUI=400, Default=Auto}" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <esri:MapView x:Name="MyMapView" Grid.Row="1" Grid.RowSpan="2" />

--- a/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSceneSample.xaml
+++ b/src/Samples/Toolkit.SampleApp.Maui/Samples/SearchViewSceneSample.xaml
@@ -13,7 +13,7 @@
         <Grid RowSpacing="0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="32" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition Height="{OnPlatform WinUI=400, Default=Auto}" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <esri:SceneView


### PR DESCRIPTION
Grid wasn't resizing searchview when the suggestions view became visible.

Before: search suggestions don't appear on MAUI WinUI
After: Search samples work as expected